### PR TITLE
v2.0.5 done，show detail =>

### DIFF
--- a/CHANGRLOG.md
+++ b/CHANGRLOG.md
@@ -1,3 +1,10 @@
+# 2.0.5
+* cli[add]: eros install all 可同时下载两端的 eros-sdk
+* cli[add]: 支持在 init 的时候输入安卓的包名
+* cli[fix]: eros mock 报错问题
+* cli[mod]: eros cli 的帮助日志更新
+* cli[del]: 由于 widget 已提交到 npm 上，目录下不在存在 widget，所以去掉 eros update widget 指令
+
 # 2.0.4
 * fix: eros pack all 失效问题
 * fix: eros pack ios 失效问题

--- a/CHANGRLOG.md
+++ b/CHANGRLOG.md
@@ -1,3 +1,8 @@
+# 2.0.4
+* fix: eros pack all 失效问题
+* fix: eros pack ios 失效问题
+* fix: eros pack android 失效问题
+
 # 2.0.3
 * add: eros pack all
 * add: eros pack ios

--- a/CHANGRLOG.md
+++ b/CHANGRLOG.md
@@ -1,3 +1,8 @@
+# 2.0.3
+* add: eros pack all
+* add: eros pack ios
+* add: eros pack android
+
 # 2.0.2
 * add: eros install ios
 * add: eros install android

--- a/README.md
+++ b/README.md
@@ -73,15 +73,58 @@ eros developed many functions based on weex (self-module), you don't have to wor
 ```
 $ eros install
 ```
+
+install eros ios sdk.
+```
+$ eros install ios
+```
+install eros android sdk.
+```
+$ eros install android
+```
+install both sdk.
+```
+$ eros install all
+```
 #### **pack**
 build prod's full zip and send it to platforms's ios/android built-in package storage path.
 ```
 $ eros pack
 ```
+
+pack eros ios inner js bundle.
+```
+$ eros pack ios
+```
+pack eros android inner js bundle.
+```
+$ eros pack android 
+```
+pack eros ios && android inner js bundle.
+```
+$ eros pack all
+```
 #### **update**
 you can update [eros-template](https://github.com/bmfe/eros-template)'s every file/path when eros-template has updated, **`but your must use it be careful, when the file/path has be changed by yourself that you want to update`**. 
 ```
 $ eros update
+```
+
+update eros ios sdk.
+```
+$ eros update ios
+```
+update eros android sdk.
+```
+$ eros update android 
+```
+update widget.
+```
+$ eros update all
+```
+update template by path.
+```
+$ eros update template path
 ```
 #### **mock**
 start mock server, you can change default `proxy` and `mockServer` in `eros-template/config/eros.dev.js`.

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -34,21 +34,6 @@ function helpCommand() {
 }
 
 var questions = [{
-    type: 'list',
-    name: 'template',
-    message: 'Choice a template.',
-    choices: [{
-            name: "standard | with default's widgets",
-            value: "eros-template"
-        },
-        new inquirer.Separator(),
-        {
-            name: "simple | without default's widgets",
-            value: "eros-template-simple",
-            disabled: 'Unavailable at this time'
-        },
-    ]
-}, {
     type: 'input',
     name: 'name',
     default: function() {
@@ -78,6 +63,20 @@ var questions = [{
         }
         return 'Your input contain illegal character, please try again.';
     }
+}, {
+    type: 'input',
+    name: 'applicationID',
+    default: function() {
+        return 'com.benmu.wx';
+    },
+    message: "Input init android application id?",
+    validate: function(value) {
+        var pass = value.match(/^[a-z\.]+$/);
+        if (pass) {
+            return true;
+        }
+        return 'Your input contain illegal character, please try again.';
+    }
 }]
 
 function changeFile(path, oldText, newText) {
@@ -87,28 +86,29 @@ function changeFile(path, oldText, newText) {
         fs.writeFileSync(path, result, 'utf8');
     }
 };
-
+const TEMPLATE = 'eros-template'
 function create() {
     inquirer.prompt(questions).then(function(answers) {
         let _answers = JSON.parse(JSON.stringify(answers))
 
-        let { name, template, version } = _answers
+        let { name, version, applicationID } = _answers
 
         const spinner = ora('downloading template'),
             tmp = path.resolve(process.cwd(), name)
 
         spinner.start();
         if (exists(tmp)) rm(tmp);
-        download(`bmfe/${template}`, tmp, function(err) {
+        download(`bmfe/${TEMPLATE}`, tmp, function(err) {
             spinner.stop()
 
-            if (err) logger.fatal('Failed to download repo ' + template + ': ' + err.message.trim())
-            changeFile(tmp + '/package.json', `${template}-name`, name)
-            changeFile(tmp + '/package.json', `${template}-version`, version)
+            if (err) logger.fatal('Failed to download repo ' + TEMPLATE + ': ' + err.message.trim())
+            changeFile(tmp + '/package.json', `${TEMPLATE}-name`, name)
 
-            changeFile(tmp + '/config/eros.native.js', `${template}-name`, name)
-            changeFile(tmp + '/config/eros.native.js', `${template}-version`, version)
-            
+            changeFile(tmp + '/config/eros.native.js', `${TEMPLATE}-name`, name)
+            changeFile(tmp + '/config/eros.native.js', `${TEMPLATE}-version`, version)
+            changeFile(tmp + '/platforms/android/WeexFrameworkWrapper/gradle.properties', `${TEMPLATE}-application-id`, applicationID)
+
+
             logger.sep()
             logger.success('Generated "%s".', name)
             logger.sep()
@@ -119,6 +119,7 @@ function create() {
         })
     });
 };
+
 
 function run() {
     if (argv.h || argv.help) {

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -3,7 +3,7 @@ var argv = require('yargs').argv,
     inquirer = require('inquirer'),
     print = require('../../utils/print'),
     logger = require('../../utils/logger'),
-    util = require('./util');
+    util = require('./util')
 
 
 var config = {
@@ -14,14 +14,14 @@ var config = {
         keys: ['-h', '--help'],
         describe: 'read help'
     }, {
-        keys: ['-ios'],
+        keys: ['ios'],
         describe: 'install ios platform base library.'
     }, {
-        keys: ['-android'],
+        keys: ['android'],
         describe: 'install android platform base library.'
     }, {
-        keys: ['-component'],
-        describe: 'install component library.'
+        keys: ['all'],
+        describe: 'install android and ios platform base library.'
     }]
 }
 
@@ -38,29 +38,32 @@ var questions = [{
     name: 'platform',
     message: 'You can install or update eros sdk and librarys.',
     choices: [{
-            name: "platform | ios ",
+            name: "eros-sdk | ios ",
             value: "runiOSInstallScript"
         }, {
-            name: "platform | android",
+            name: "eros-sdk | android",
             value: "runAndroidInstallScript"
+        }, {
+            name: "eros-sdk | ios & android",
+            value: "runAllInstallScript"
         }
     ]
 }]
 
 function installSelect() {
     inquirer.prompt(questions).then(function(answers) {
-        var platform = JSON.parse(JSON.stringify(answers)).platform;
-        util[platform] && util[platform]();
+        var platform = JSON.parse(JSON.stringify(answers)).platform
+        util[platform] && util[platform]()
     }, (error) => {
         logger.fatal('input error'.red)
         logger.fatal(error)
-    });
+    })
 }
 
 
 function run() {
     if (argv.h || argv.help) {
-        helpCommand();
+        helpCommand()
         return
     }
     if (argv._[1] === 'ios'){
@@ -70,14 +73,18 @@ function run() {
     if(argv._[1] === 'android') {
         util.runAndroidInstallScript()
         return
-    } 
+    }
+    if(argv._[1] === 'all') {
+        util.runAllInstallScript()
+        return
+    }     
 
     if (argv.ios) {
-        util.installIosDep();
+        util.installIosDep()
     } else if (argv.android) {
-        util.installAndroidDep();
+        util.installAndroidDep()
     } else {
-        installSelect();
+        installSelect()
     }
 }
 

--- a/lib/commands/mock.js
+++ b/lib/commands/mock.js
@@ -62,7 +62,7 @@ function listenPort(server, port) {
     server.on('listening', function(e) {
         print.log('server 运行成功, 端口为 ' + port);
         print.log('按 Ctrl + C 结束进程');
-        gulp.start('mock');
+        gulp.start('start-mock');
     });
     return server.listen(port);
 }

--- a/lib/commands/pack.js
+++ b/lib/commands/pack.js
@@ -74,11 +74,11 @@ function run() {
         return
     }
 
-    if (argv.ios) {
+    if (argv.ios || argv[1] === 'ios') {
         packContainer.ios()
-    } else if (argv.android) {
+    } else if (argv.android || argv[1] === 'android') {
         packContainer.android()
-    } else if(argv.all) {
+    } else if(argv.all || argv[1] === 'all') {
         packContainer.all()
     } else {
         select();

--- a/lib/commands/pack.js
+++ b/lib/commands/pack.js
@@ -13,10 +13,10 @@ var config = {
         keys: ['-h', '--help'],
         describe: 'read help'
     }, {
-        keys: ['-ios'],
+        keys: ['ios'],
         describe: 'pack ios full dose zip and send to eros ios platform.'
     }, {
-        keys: ['-android'],
+        keys: ['android'],
         describe: 'pack ios full dose zip and send to eros android platform.'
     }]
 }

--- a/lib/commands/pack.js
+++ b/lib/commands/pack.js
@@ -73,12 +73,11 @@ function run() {
         helpCommand();
         return
     }
-
-    if (argv.ios || argv[1] === 'ios') {
+    if (argv.ios || argv._[1] === 'ios') {
         packContainer.ios()
-    } else if (argv.android || argv[1] === 'android') {
+    } else if (argv.android || argv._[1] === 'android') {
         packContainer.android()
-    } else if(argv.all || argv[1] === 'all') {
+    } else if(argv.all || argv._[1] === 'all') {
         packContainer.all()
     } else {
         select();

--- a/lib/commands/server/webpack.config.js
+++ b/lib/commands/server/webpack.config.js
@@ -20,11 +20,13 @@ var webpackConfig = {
     module: {
         rules: [{
             test: /\.vue$/,
-            loader: 'weex-loader',
-            options: {
-                stylus: 'vue-style-loader!css-loader!stylus-loader',
-                styl: 'vue-style-loader!css-loader!stylus-loader'
-            }
+            use: [{
+                loader: 'weex-loader',
+                options: {
+                    stylus: 'vue-style-loader!css-loader!stylus-loader',
+                    styl: 'vue-style-loader!css-loader!stylus-loader'
+                }                
+            }]
         }, {
             test: /\.(jsx?|babel|es6)$/,
             loader: 'babel-loader'

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -151,10 +151,10 @@ function run() {
         util.runAndroidUpdateScript()
         return
     }
-    if(argv._[1] === 'widget') {
-        update("eros-template", 'src/js/widget')
-        return
-    } 
+    // if(argv._[1] === 'widget') {
+    //     update("eros-template", 'src/js/widget')
+    //     return
+    // } 
     if(argv._[1] === 'template' && !argv._[2]) {
         logger.fatal('please input the update path')
         return

--- a/lib/commands/util.js
+++ b/lib/commands/util.js
@@ -52,10 +52,11 @@ function installAndroidDep() {
     });
 };
 
-function runiOSInstallScript () {
+function runiOSInstallScript (callback) {
     console.time('[' + 'eros'.blue + '] ' + 'ios installing time consuming: '.green);
     var build = Process.exec(path.resolve(process.cwd(), './scripts/install.ios.sh'),  { cwd: process.cwd() }, function(error, stdout, stderr) {
         console.timeEnd('[' + 'eros'.blue + '] ' + 'ios installing time consuming: '.green);
+        callback && callback();
     });
     build.stdout.on('data', function(data) {
         console.log(data)
@@ -64,10 +65,11 @@ function runiOSInstallScript () {
         console.log(data)
     });
 }
-function runAndroidInstallScript () {
+function runAndroidInstallScript (callback) {
     console.time('[' + 'eros'.blue + '] ' + 'android installing time consuming: '.green);
     var build = Process.exec(path.resolve(process.cwd(), './scripts/install.android.sh'), { cwd: process.cwd() }, function(error, stdout, stderr) {
         console.timeEnd('[' + 'eros'.blue + '] ' + 'android installing time consuming: '.green);
+        callback && callback();
     });
     build.stdout.on('data', function(data) {
         console.log(data)
@@ -75,6 +77,10 @@ function runAndroidInstallScript () {
     build.stderr.on('data', function(data) {
         console.log(data)
     });
+}
+
+function runAllInstallScript () {
+    runiOSInstallScript(runAndroidInstallScript);
 }
 
 function runiOSUpdateScript () {
@@ -107,6 +113,7 @@ module.exports = {
     installAndroidDep: installAndroidDep,
     runiOSInstallScript: runiOSInstallScript,
     runAndroidInstallScript: runAndroidInstallScript,
+    runAllInstallScript: runAllInstallScript,
     runiOSUpdateScript: runiOSUpdateScript,
     runAndroidUpdateScript: runAndroidUpdateScript
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eros-cli",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A simple CLI for scaffolding weex projects, we provide eros-template to quickly build small and medium sized app.",
   "bin": {
     "eros": "./bin/eros.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eros-cli",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A simple CLI for scaffolding weex projects, we provide eros-template to quickly build small and medium sized app.",
   "bin": {
     "eros": "./bin/eros.js"
@@ -27,9 +27,9 @@
     "css-loader": "^0.28.4",
     "download-git-repo": "^1.0.1",
     "eslint": "^4.15.0",
+    "eslint-config-vue": "^2.0.2",
     "eslint-friendly-formatter": "^3.0.0",
     "eslint-loader": "^1.9.0",
-    "eslint-config-vue": "^2.0.2",
     "eslint-plugin-html": "^4.0.1",
     "eslint-plugin-vue": "^4.1.0",
     "glob": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eros-cli",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A simple CLI for scaffolding weex projects, we provide eros-template to quickly build small and medium sized app.",
   "bin": {
     "eros": "./bin/eros.js"


### PR DESCRIPTION
* [add]: eros install all 可同时下载两端的 eros-sdk
* [add]: 支持在 init 的时候输入安卓的包名
* [fix]: eros mock 报错问题
* [mod]: eros cli 的帮助日志更新
* [del]: 由于 widget 已提交到 npm 上，目录下不在存在 widget，所以去掉 eros update widget 指令