### PR TITLE
node_env 环境变量兼容问题

### DIFF
--- a/lib/commands/server/webpack.config.js
+++ b/lib/commands/server/webpack.config.js
@@ -27,7 +27,7 @@ var webpackConfig = {
                         'scss': ['weex-vue-loader/lib/style-loader','sass-loader'],
                         'stylus': ['stylus-loader']
                     }
-                }                
+                }
             }]
         }, {
             test: /\.(jsx?|babel|es6)$/,
@@ -78,14 +78,14 @@ if (isDev) {
         }
     }, readConfig.get('webpackDevEnv') || []))], readConfig.get('webpackDevPlugins') || []);
 } else if (isProd) {
-   
+
     webpackConfig.devtool = readConfig.get('webpackProdtool') || 'cheap-module-source-map';
     webpackConfig.plugins = webpackConfig.plugins.concat([
         new webpack.DefinePlugin(Object.assign({
         'process.env': {
-            NODE_ENV: JSON.stringify('production')
+            NODE_ENV: JSON.stringify(process.env.NODE_ENV) || JSON.stringify('production')
         }
-    }, readConfig.get('webpackProdEnv') || [])), 
+    }, readConfig.get('webpackProdEnv') || [])),
         new webpack.LoaderOptionsPlugin({
           minimize: true,
           debug: false

--- a/lib/commands/server/webpack.config.new.js
+++ b/lib/commands/server/webpack.config.new.js
@@ -62,16 +62,16 @@ const nativeCfg = {
                 test: /\.js$/,
                 use: 'happypack/loader?id=babel',
                 include: [
-                    resolve('node_modules'), 
+                    resolve('node_modules'),
                     resolve('src')
                 ]
             },
             {
                 test: /\.vue(\?[^?]+)?$/,
                 include: [
-                    resolve('node_modules'), 
+                    resolve('node_modules'),
                     resolve('src')
-                ],                
+                ],
                 use: [{
                     loader: 'weex-loader',
                     options: {
@@ -126,7 +126,7 @@ if (isDev) {
     nativeCfg.plugins = nativeCfg.plugins.concat([
         new webpack.DefinePlugin({
             'process.env': {
-                NODE_ENV: JSON.stringify('production')
+                NODE_ENV: JSON.stringify(process.env.NODE_ENV) || JSON.stringify('production')
             },
             global: '{}'
         }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,144 @@
 {
     "name": "eros-cli",
-    "version": "2.0.0-beta.1",
+    "version": "2.0.7-beta.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0-beta.44",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+            "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+            "requires": {
+                "@babel/highlight": "7.0.0-beta.44"
+            }
+        },
+        "@babel/generator": {
+            "version": "7.0.0-beta.44",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+            "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+            "requires": {
+                "@babel/types": "7.0.0-beta.44",
+                "jsesc": "2.5.1",
+                "lodash": "4.15.0",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+                    "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+                }
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.0.0-beta.44",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+            "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+            "requires": {
+                "@babel/helper-get-function-arity": "7.0.0-beta.44",
+                "@babel/template": "7.0.0-beta.44",
+                "@babel/types": "7.0.0-beta.44"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0-beta.44",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+            "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+            "requires": {
+                "@babel/types": "7.0.0-beta.44"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.0.0-beta.44",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+            "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+            "requires": {
+                "@babel/types": "7.0.0-beta.44"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0-beta.44",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+            "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+            "requires": {
+                "chalk": "2.3.0",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            }
+        },
+        "@babel/template": {
+            "version": "7.0.0-beta.44",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+            "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+            "requires": {
+                "@babel/code-frame": "7.0.0-beta.44",
+                "@babel/types": "7.0.0-beta.44",
+                "babylon": "7.0.0-beta.44",
+                "lodash": "4.15.0"
+            },
+            "dependencies": {
+                "babylon": {
+                    "version": "7.0.0-beta.44",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+                    "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
+                }
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.0.0-beta.44",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+            "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+            "requires": {
+                "@babel/code-frame": "7.0.0-beta.44",
+                "@babel/generator": "7.0.0-beta.44",
+                "@babel/helper-function-name": "7.0.0-beta.44",
+                "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+                "@babel/types": "7.0.0-beta.44",
+                "babylon": "7.0.0-beta.44",
+                "debug": "3.1.0",
+                "globals": "11.4.0",
+                "invariant": "2.2.2",
+                "lodash": "4.15.0"
+            },
+            "dependencies": {
+                "babylon": {
+                    "version": "7.0.0-beta.44",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+                    "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "globals": {
+                    "version": "11.4.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+                    "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA=="
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.0.0-beta.44",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+            "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+            "requires": {
+                "esutils": "2.0.2",
+                "lodash": "4.15.0",
+                "to-fast-properties": "2.0.0"
+            },
+            "dependencies": {
+                "to-fast-properties": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+                }
+            }
+        },
         "JSONStream": {
             "version": "1.3.1",
             "resolved": "http://registry.npm.taobao.org/JSONStream/download/JSONStream-1.3.1.tgz",
@@ -72,6 +207,21 @@
                     "version": "4.0.13",
                     "resolved": "http://registry.npm.taobao.org/acorn/download/acorn-4.0.13.tgz",
                     "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+                }
+            }
+        },
+        "acorn-jsx": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+            "requires": {
+                "acorn": "3.3.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
                 }
             }
         },
@@ -357,8 +507,7 @@
         "asap": {
             "version": "2.0.6",
             "resolved": "http://registry.npm.taobao.org/asap/download/asap-2.0.6.tgz",
-            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-            "optional": true
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
         },
         "asn1": {
             "version": "0.2.3",
@@ -404,11 +553,6 @@
                 }
             }
         },
-        "async": {
-            "version": "0.2.10",
-            "resolved": "http://registry.npm.taobao.org/async/download/async-0.2.10.tgz",
-            "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-        },
         "async-each": {
             "version": "1.0.1",
             "resolved": "http://registry.npm.taobao.org/async-each/download/async-each-1.0.1.tgz",
@@ -418,6 +562,11 @@
             "version": "0.1.3",
             "resolved": "http://registry.npm.taobao.org/async-foreach/download/async-foreach-0.1.3.tgz",
             "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+        },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
         },
         "asynckit": {
             "version": "0.4.0",
@@ -521,6 +670,26 @@
                 }
             }
         },
+        "babel-eslint": {
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.3.tgz",
+            "integrity": "sha512-0HeSTtaXg/Em7FCUWxwOT+KeFSO1O7LuRuzhk7g+1BjwdlQGlHq4OyMi3GqGxrNfEq8jEi6Hmt5ylEQUhurgiQ==",
+            "requires": {
+                "@babel/code-frame": "7.0.0-beta.44",
+                "@babel/traverse": "7.0.0-beta.44",
+                "@babel/types": "7.0.0-beta.44",
+                "babylon": "7.0.0-beta.44",
+                "eslint-scope": "3.7.1",
+                "eslint-visitor-keys": "1.0.0"
+            },
+            "dependencies": {
+                "babylon": {
+                    "version": "7.0.0-beta.44",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+                    "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
+                }
+            }
+        },
         "babel-generator": {
             "version": "6.26.0",
             "resolved": "http://registry.npm.taobao.org/babel-generator/download/babel-generator-6.26.0.tgz",
@@ -541,26 +710,6 @@
                     "resolved": "http://registry.npm.taobao.org/lodash/download/lodash-4.17.4.tgz",
                     "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
                 }
-            }
-        },
-        "babel-helper-bindify-decorators": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-helper-bindify-decorators/download/babel-helper-bindify-decorators-6.24.1.tgz",
-            "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-helper-builder-binary-assignment-operator-visitor": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-helper-builder-binary-assignment-operator-visitor/download/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-            "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-            "requires": {
-                "babel-helper-explode-assignable-expression": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
             }
         },
         "babel-helper-call-delegate": {
@@ -590,27 +739,6 @@
                     "resolved": "http://registry.npm.taobao.org/lodash/download/lodash-4.17.4.tgz",
                     "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
                 }
-            }
-        },
-        "babel-helper-explode-assignable-expression": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-helper-explode-assignable-expression/download/babel-helper-explode-assignable-expression-6.24.1.tgz",
-            "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-            "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-helper-explode-class": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-helper-explode-class/download/babel-helper-explode-class-6.24.1.tgz",
-            "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-            "requires": {
-                "babel-helper-bindify-decorators": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
             }
         },
         "babel-helper-function-name": {
@@ -669,18 +797,6 @@
                 }
             }
         },
-        "babel-helper-remap-async-to-generator": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-helper-remap-async-to-generator/download/babel-helper-remap-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-            "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
         "babel-helper-replace-supers": {
             "version": "6.24.1",
             "resolved": "http://registry.npm.taobao.org/babel-helper-replace-supers/download/babel-helper-replace-supers-6.24.1.tgz",
@@ -726,128 +842,6 @@
             "resolved": "http://registry.npm.taobao.org/babel-plugin-check-es2015-constants/download/babel-plugin-check-es2015-constants-6.22.0.tgz",
             "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
             "requires": {
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-syntax-async-functions": {
-            "version": "6.13.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-async-functions/download/babel-plugin-syntax-async-functions-6.13.0.tgz",
-            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
-        },
-        "babel-plugin-syntax-async-generators": {
-            "version": "6.13.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-async-generators/download/babel-plugin-syntax-async-generators-6.13.0.tgz",
-            "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
-        },
-        "babel-plugin-syntax-class-constructor-call": {
-            "version": "6.18.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-class-constructor-call/download/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-            "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
-        },
-        "babel-plugin-syntax-class-properties": {
-            "version": "6.13.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-class-properties/download/babel-plugin-syntax-class-properties-6.13.0.tgz",
-            "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
-        },
-        "babel-plugin-syntax-decorators": {
-            "version": "6.13.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-decorators/download/babel-plugin-syntax-decorators-6.13.0.tgz",
-            "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
-        },
-        "babel-plugin-syntax-do-expressions": {
-            "version": "6.13.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-do-expressions/download/babel-plugin-syntax-do-expressions-6.13.0.tgz",
-            "integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0="
-        },
-        "babel-plugin-syntax-dynamic-import": {
-            "version": "6.18.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-dynamic-import/download/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-            "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
-        },
-        "babel-plugin-syntax-exponentiation-operator": {
-            "version": "6.13.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-exponentiation-operator/download/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-            "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
-        },
-        "babel-plugin-syntax-export-extensions": {
-            "version": "6.13.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-export-extensions/download/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-            "integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
-        },
-        "babel-plugin-syntax-function-bind": {
-            "version": "6.13.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-function-bind/download/babel-plugin-syntax-function-bind-6.13.0.tgz",
-            "integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y="
-        },
-        "babel-plugin-syntax-object-rest-spread": {
-            "version": "6.13.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-object-rest-spread/download/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-            "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
-        },
-        "babel-plugin-syntax-trailing-function-commas": {
-            "version": "6.22.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-trailing-function-commas/download/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-        },
-        "babel-plugin-transform-async-generator-functions": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-async-generator-functions/download/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
-            "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-            "requires": {
-                "babel-helper-remap-async-to-generator": "6.24.1",
-                "babel-plugin-syntax-async-generators": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-async-to-generator": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-async-to-generator/download/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-            "requires": {
-                "babel-helper-remap-async-to-generator": "6.24.1",
-                "babel-plugin-syntax-async-functions": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-class-constructor-call": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-class-constructor-call/download/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
-            "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
-            "requires": {
-                "babel-plugin-syntax-class-constructor-call": "6.18.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-class-properties": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-class-properties/download/babel-plugin-transform-class-properties-6.24.1.tgz",
-            "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-            "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-plugin-syntax-class-properties": "6.13.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-decorators": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-decorators/download/babel-plugin-transform-decorators-6.24.1.tgz",
-            "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-            "requires": {
-                "babel-helper-explode-class": "6.24.1",
-                "babel-plugin-syntax-decorators": "6.13.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-types": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-do-expressions": {
-            "version": "6.22.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-do-expressions/download/babel-plugin-transform-do-expressions-6.22.0.tgz",
-            "integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
-            "requires": {
-                "babel-plugin-syntax-do-expressions": "6.13.0",
                 "babel-runtime": "6.26.0"
             }
         },
@@ -1070,43 +1064,6 @@
                 "regexpu-core": "2.0.0"
             }
         },
-        "babel-plugin-transform-exponentiation-operator": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-exponentiation-operator/download/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-            "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-            "requires": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-                "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-export-extensions": {
-            "version": "6.22.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-export-extensions/download/babel-plugin-transform-export-extensions-6.22.0.tgz",
-            "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
-            "requires": {
-                "babel-plugin-syntax-export-extensions": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-function-bind": {
-            "version": "6.22.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-function-bind/download/babel-plugin-transform-function-bind-6.22.0.tgz",
-            "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
-            "requires": {
-                "babel-plugin-syntax-function-bind": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
-        "babel-plugin-transform-object-rest-spread": {
-            "version": "6.26.0",
-            "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-object-rest-spread/download/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-            "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-            "requires": {
-                "babel-plugin-syntax-object-rest-spread": "6.13.0",
-                "babel-runtime": "6.26.0"
-            }
-        },
         "babel-plugin-transform-regenerator": {
             "version": "6.26.0",
             "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-regenerator/download/babel-plugin-transform-regenerator-6.26.0.tgz",
@@ -1130,43 +1087,6 @@
             "requires": {
                 "babel-runtime": "6.26.0",
                 "babel-types": "6.26.0"
-            }
-        },
-        "babel-preset-env": {
-            "version": "1.6.1",
-            "resolved": "http://registry.npm.taobao.org/babel-preset-env/download/babel-preset-env-1.6.1.tgz",
-            "integrity": "sha1-oYtWTMm5r99KrleuPBsNmRiOb0g=",
-            "requires": {
-                "babel-plugin-check-es2015-constants": "6.22.0",
-                "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-                "babel-plugin-transform-async-to-generator": "6.24.1",
-                "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-                "babel-plugin-transform-es2015-classes": "6.24.1",
-                "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-                "babel-plugin-transform-es2015-destructuring": "6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-                "babel-plugin-transform-es2015-for-of": "6.23.0",
-                "babel-plugin-transform-es2015-function-name": "6.24.1",
-                "babel-plugin-transform-es2015-literals": "6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-                "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-                "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-                "babel-plugin-transform-es2015-object-super": "6.24.1",
-                "babel-plugin-transform-es2015-parameters": "6.24.1",
-                "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-                "babel-plugin-transform-es2015-spread": "6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-                "babel-plugin-transform-es2015-template-literals": "6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-                "babel-plugin-transform-exponentiation-operator": "6.24.1",
-                "babel-plugin-transform-regenerator": "6.26.0",
-                "browserslist": "2.9.0",
-                "invariant": "2.2.2",
-                "semver": "5.4.1"
             }
         },
         "babel-preset-es2015": {
@@ -1198,49 +1118,6 @@
                 "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
                 "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
                 "babel-plugin-transform-regenerator": "6.26.0"
-            }
-        },
-        "babel-preset-stage-0": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-preset-stage-0/download/babel-preset-stage-0-6.24.1.tgz",
-            "integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
-            "requires": {
-                "babel-plugin-transform-do-expressions": "6.22.0",
-                "babel-plugin-transform-function-bind": "6.22.0",
-                "babel-preset-stage-1": "6.24.1"
-            }
-        },
-        "babel-preset-stage-1": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-preset-stage-1/download/babel-preset-stage-1-6.24.1.tgz",
-            "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
-            "requires": {
-                "babel-plugin-transform-class-constructor-call": "6.24.1",
-                "babel-plugin-transform-export-extensions": "6.22.0",
-                "babel-preset-stage-2": "6.24.1"
-            }
-        },
-        "babel-preset-stage-2": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-preset-stage-2/download/babel-preset-stage-2-6.24.1.tgz",
-            "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-            "requires": {
-                "babel-plugin-syntax-dynamic-import": "6.18.0",
-                "babel-plugin-transform-class-properties": "6.24.1",
-                "babel-plugin-transform-decorators": "6.24.1",
-                "babel-preset-stage-3": "6.24.1"
-            }
-        },
-        "babel-preset-stage-3": {
-            "version": "6.24.1",
-            "resolved": "http://registry.npm.taobao.org/babel-preset-stage-3/download/babel-preset-stage-3-6.24.1.tgz",
-            "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-            "requires": {
-                "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-                "babel-plugin-transform-async-generator-functions": "6.24.1",
-                "babel-plugin-transform-async-to-generator": "6.24.1",
-                "babel-plugin-transform-exponentiation-operator": "6.24.1",
-                "babel-plugin-transform-object-rest-spread": "6.26.0"
             }
         },
         "babel-register": {
@@ -1752,15 +1629,6 @@
                 "pako": "0.2.9"
             }
         },
-        "browserslist": {
-            "version": "2.9.0",
-            "resolved": "http://registry.npm.taobao.org/browserslist/download/browserslist-2.9.0.tgz",
-            "integrity": "sha1-cGrKFcU74VYQ9GbjSMv6DACmo3k=",
-            "requires": {
-                "caniuse-lite": "1.0.30000760",
-                "electron-to-chromium": "1.3.27"
-            }
-        },
         "buffer": {
             "version": "3.6.0",
             "resolved": "http://registry.npm.taobao.org/buffer/download/buffer-3.6.0.tgz",
@@ -1801,6 +1669,14 @@
             "resolved": "http://registry.npm.taobao.org/cached-path-relative/download/cached-path-relative-1.0.1.tgz",
             "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc="
         },
+        "caller-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+            "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+            "requires": {
+                "callsites": "0.2.0"
+            }
+        },
         "callsite": {
             "version": "1.0.0",
             "resolved": "http://registry.npm.taobao.org/callsite/download/callsite-1.0.0.tgz",
@@ -1837,6 +1713,11 @@
                     "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
                 }
             }
+        },
+        "callsites": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
         },
         "camelcase": {
             "version": "2.1.1",
@@ -1878,11 +1759,6 @@
             "version": "1.0.30000760",
             "resolved": "http://registry.npm.taobao.org/caniuse-db/download/caniuse-db-1.0.30000760.tgz",
             "integrity": "sha1-PqKUc+t4psywny63Osnh3r/sUo0="
-        },
-        "caniuse-lite": {
-            "version": "1.0.30000760",
-            "resolved": "http://registry.npm.taobao.org/caniuse-lite/download/caniuse-lite-1.0.30000760.tgz",
-            "integrity": "sha1-7HIDlXQvHH7IlH/W3SYE53qPmP8="
         },
         "capture-stack-trace": {
             "version": "1.0.0",
@@ -1976,6 +1852,11 @@
                 "inherits": "2.0.3",
                 "safe-buffer": "5.1.1"
             }
+        },
+        "circular-json": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
         },
         "clap": {
             "version": "1.2.3",
@@ -2076,23 +1957,15 @@
                 "q": "1.5.1"
             }
         },
+        "coalescy": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/coalescy/-/coalescy-1.0.0.tgz",
+            "integrity": "sha1-SwZYRrg2NhrabEtKSr9LwcrDG/E="
+        },
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "http://registry.npm.taobao.org/code-point-at/download/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "coffee-loader": {
-            "version": "0.7.3",
-            "resolved": "http://registry.npm.taobao.org/coffee-loader/download/coffee-loader-0.7.3.tgz",
-            "integrity": "sha1-+tvG79b8fsyIxbMEaiwpIGa8tUo=",
-            "requires": {
-                "loader-utils": "1.1.0"
-            }
-        },
-        "coffee-script": {
-            "version": "1.12.7",
-            "resolved": "http://registry.npm.taobao.org/coffee-script/download/coffee-script-1.12.7.tgz",
-            "integrity": "sha1-wF2uDLeVkdBbMHCoQzqYyaiczFM="
         },
         "color": {
             "version": "0.11.4",
@@ -2230,14 +2103,6 @@
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.3",
                 "typedarray": "0.0.6"
-            }
-        },
-        "concat-with-sourcemaps": {
-            "version": "1.0.4",
-            "resolved": "http://registry.npm.taobao.org/concat-with-sourcemaps/download/concat-with-sourcemaps-1.0.4.tgz",
-            "integrity": "sha1-9Vs74q60dgGxCi1SWcz7cP0vHdY=",
-            "requires": {
-                "source-map": "0.5.7"
             }
         },
         "config-chain": {
@@ -2520,6 +2385,42 @@
                 "boom": "2.10.1"
             }
         },
+        "cryptlib": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/cryptlib/-/cryptlib-1.0.3.tgz",
+            "integrity": "sha1-+wW6rlPfI03CC4Lob61WSYcGLWE=",
+            "requires": {
+                "bl": "1.0.0"
+            },
+            "dependencies": {
+                "bl": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                    "integrity": "sha1-ramoqJptesYIYvfex9sgeHPgw/U=",
+                    "requires": {
+                        "readable-stream": "2.0.6"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                }
+            }
+        },
         "crypto-browserify": {
             "version": "3.12.0",
             "resolved": "http://registry.npm.taobao.org/crypto-browserify/download/crypto-browserify-3.12.0.tgz",
@@ -2725,11 +2626,6 @@
             "resolved": "http://registry.npm.taobao.org/de-indent/download/de-indent-1.0.2.tgz",
             "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
         },
-        "deap": {
-            "version": "1.0.0",
-            "resolved": "http://registry.npm.taobao.org/deap/download/deap-1.0.0.tgz",
-            "integrity": "sha1-sUi/gkMKJ2mbdIOgPra2dYW/yIg="
-        },
         "debug": {
             "version": "2.6.9",
             "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
@@ -2863,6 +2759,40 @@
             "version": "1.0.0",
             "resolved": "http://registry.npm.taobao.org/defined/download/defined-1.0.0.tgz",
             "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+        },
+        "del": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+            "requires": {
+                "globby": "5.0.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.1",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.6.2"
+            },
+            "dependencies": {
+                "globby": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+                    "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+                    "requires": {
+                        "array-union": "1.0.2",
+                        "arrify": "1.0.1",
+                        "glob": "7.0.6",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                }
+            }
         },
         "delayed-stream": {
             "version": "1.0.0",
@@ -3161,10 +3091,56 @@
                 "randombytes": "2.0.5"
             }
         },
+        "doctrine": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+            "requires": {
+                "esutils": "2.0.2"
+            }
+        },
+        "dom-serializer": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+            "requires": {
+                "domelementtype": "1.1.3",
+                "entities": "1.1.1"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                    "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+                }
+            }
+        },
         "domain-browser": {
             "version": "1.1.7",
             "resolved": "http://registry.npm.taobao.org/domain-browser/download/domain-browser-1.1.7.tgz",
             "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
+        },
+        "domelementtype": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+            "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+        },
+        "domhandler": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+            "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+            "requires": {
+                "domelementtype": "1.3.0"
+            }
+        },
+        "domutils": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+            "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+            "requires": {
+                "dom-serializer": "0.1.0",
+                "domelementtype": "1.3.0"
+            }
         },
         "dot-prop": {
             "version": "4.2.0",
@@ -3204,11 +3180,6 @@
                 "git-clone": "0.1.0",
                 "rimraf": "2.6.2"
             }
-        },
-        "duplexer": {
-            "version": "0.1.1",
-            "resolved": "http://registry.npm.taobao.org/duplexer/download/duplexer-0.1.1.tgz",
-            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
         },
         "duplexer2": {
             "version": "0.0.2",
@@ -3306,6 +3277,11 @@
                 "minimalistic-crypto-utils": "1.0.1"
             }
         },
+        "emitter-mixin": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/emitter-mixin/-/emitter-mixin-0.0.3.tgz",
+            "integrity": "sha1-WUjLKG8uSO3DslGnz8H3iDOW1lw="
+        },
         "emojis-list": {
             "version": "2.1.0",
             "resolved": "http://registry.npm.taobao.org/emojis-list/download/emojis-list-2.1.0.tgz",
@@ -3334,6 +3310,11 @@
                 "object-assign": "4.1.1",
                 "tapable": "0.2.8"
             }
+        },
+        "entities": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+            "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
         },
         "errno": {
             "version": "0.1.4",
@@ -3477,10 +3458,279 @@
                 "estraverse": "4.2.0"
             }
         },
+        "eslint": {
+            "version": "4.19.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+            "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+            "requires": {
+                "ajv": "5.5.2",
+                "babel-code-frame": "6.26.0",
+                "chalk": "2.3.0",
+                "concat-stream": "1.6.0",
+                "cross-spawn": "5.1.0",
+                "debug": "3.1.0",
+                "doctrine": "2.1.0",
+                "eslint-scope": "3.7.1",
+                "eslint-visitor-keys": "1.0.0",
+                "espree": "3.5.4",
+                "esquery": "1.0.1",
+                "esutils": "2.0.2",
+                "file-entry-cache": "2.0.0",
+                "functional-red-black-tree": "1.0.1",
+                "glob": "7.1.2",
+                "globals": "11.4.0",
+                "ignore": "3.3.7",
+                "imurmurhash": "0.1.4",
+                "inquirer": "3.3.0",
+                "is-resolvable": "1.1.0",
+                "js-yaml": "3.11.0",
+                "json-stable-stringify-without-jsonify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "path-is-inside": "1.0.2",
+                "pluralize": "7.0.0",
+                "progress": "2.0.0",
+                "regexpp": "1.1.0",
+                "require-uncached": "1.0.3",
+                "semver": "5.4.1",
+                "strip-ansi": "4.0.0",
+                "strip-json-comments": "2.0.1",
+                "table": "4.0.2",
+                "text-table": "0.2.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "requires": {
+                        "co": "4.6.0",
+                        "fast-deep-equal": "1.0.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                },
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "requires": {
+                        "lru-cache": "4.1.2",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.0"
+                    }
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "esprima": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+                    "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+                },
+                "fast-levenshtein": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+                    "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "globals": {
+                    "version": "11.4.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+                    "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA=="
+                },
+                "js-yaml": {
+                    "version": "3.11.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+                    "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+                    "requires": {
+                        "argparse": "1.0.9",
+                        "esprima": "4.0.0"
+                    }
+                },
+                "levn": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                    "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+                    "requires": {
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.5",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+                    "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+                },
+                "lru-cache": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+                    "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+                    "requires": {
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
+                    }
+                },
+                "optionator": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+                    "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+                    "requires": {
+                        "deep-is": "0.1.3",
+                        "fast-levenshtein": "2.0.6",
+                        "levn": "0.3.0",
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2",
+                        "wordwrap": "1.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                },
+                "wordwrap": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+                }
+            }
+        },
+        "eslint-config-vue": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/eslint-config-vue/-/eslint-config-vue-2.0.2.tgz",
+            "integrity": "sha1-o6sQBImeSTJ6lMY+JNR6OWsvSEg="
+        },
+        "eslint-friendly-formatter": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-friendly-formatter/-/eslint-friendly-formatter-3.0.0.tgz",
+            "integrity": "sha1-J4h0Q1psRuwdlPoLH/SU4w7wQpA=",
+            "requires": {
+                "chalk": "1.1.3",
+                "coalescy": "1.0.0",
+                "extend": "3.0.1",
+                "minimist": "1.2.0",
+                "text-table": "0.2.0"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                }
+            }
+        },
+        "eslint-loader": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.9.0.tgz",
+            "integrity": "sha512-40aN976qSNPyb9ejTqjEthZITpls1SVKtwguahmH1dzGCwQU/vySE+xX33VZmD8csU0ahVNCtFlsPgKqRBiqgg==",
+            "requires": {
+                "loader-fs-cache": "1.0.1",
+                "loader-utils": "1.1.0",
+                "object-assign": "4.1.1",
+                "object-hash": "1.3.0",
+                "rimraf": "2.6.2"
+            }
+        },
+        "eslint-plugin-html": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-4.0.3.tgz",
+            "integrity": "sha512-ArFnlfQxwYSz/CP0zvk8Cy3MUhcDpT3o6jgO8eKD/b8ezcLVBrgkYzmMv+7S/ya+Yl9pN+Cz2tsgYp/zElkQzA==",
+            "requires": {
+                "htmlparser2": "3.9.2"
+            }
+        },
+        "eslint-plugin-vue": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-4.4.0.tgz",
+            "integrity": "sha512-UHeE0aTEv9A/9xe8J6X7rDLMbwV6GuQFKAscMyLEv49Y4wK4KwQiifr2X0MsNsVlmccrDUyjI9KO4DuFTkPP9A==",
+            "requires": {
+                "vue-eslint-parser": "2.0.3"
+            }
+        },
+        "eslint-scope": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+            "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+            "requires": {
+                "esrecurse": "4.2.0",
+                "estraverse": "4.2.0"
+            }
+        },
+        "eslint-visitor-keys": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+            "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+        },
+        "espree": {
+            "version": "3.5.4",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+            "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+            "requires": {
+                "acorn": "5.5.3",
+                "acorn-jsx": "3.0.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.5.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+                }
+            }
+        },
         "esprima": {
             "version": "2.7.3",
             "resolved": "http://registry.npm.taobao.org/esprima/download/esprima-2.7.3.tgz",
             "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+        },
+        "esquery": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+            "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+            "requires": {
+                "estraverse": "4.2.0"
+            }
         },
         "esrecurse": {
             "version": "4.2.0",
@@ -3513,20 +3763,6 @@
             "requires": {
                 "d": "1.0.0",
                 "es5-ext": "0.10.35"
-            }
-        },
-        "event-stream": {
-            "version": "3.3.2",
-            "resolved": "http://registry.npm.taobao.org/event-stream/download/event-stream-3.3.2.tgz",
-            "integrity": "sha1-PMMQ/rHyjS9isqCF1zap71ZjeLg=",
-            "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
-                "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
             }
         },
         "events": {
@@ -3706,6 +3942,15 @@
                 "escape-string-regexp": "1.0.5"
             }
         },
+        "file-entry-cache": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+            "requires": {
+                "flat-cache": "1.3.0",
+                "object-assign": "4.1.1"
+            }
+        },
         "file-type": {
             "version": "5.2.0",
             "resolved": "http://registry.npm.taobao.org/file-type/download/file-type-5.2.0.tgz",
@@ -3840,10 +4085,16 @@
             "resolved": "http://registry.npm.taobao.org/flagged-respawn/download/flagged-respawn-0.3.2.tgz",
             "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU="
         },
-        "flatnest": {
-            "version": "1.0.0",
-            "resolved": "http://registry.npm.taobao.org/flatnest/download/flatnest-1.0.0.tgz",
-            "integrity": "sha1-IEIa0FtGxjytMO8UqOxiX4az8cU="
+        "flat-cache": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+            "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+            "requires": {
+                "circular-json": "0.3.3",
+                "del": "2.2.2",
+                "graceful-fs": "4.1.11",
+                "write": "0.2.1"
+            }
         },
         "flatten": {
             "version": "1.0.2",
@@ -3883,11 +4134,6 @@
             "version": "0.3.0",
             "resolved": "http://registry.npm.taobao.org/fresh/download/fresh-0.3.0.tgz",
             "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
-        },
-        "from": {
-            "version": "0.1.7",
-            "resolved": "http://registry.npm.taobao.org/from/download/from-0.1.7.tgz",
-            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
         },
         "fs-exists-sync": {
             "version": "0.1.0",
@@ -4830,6 +5076,11 @@
             "resolved": "http://registry.npm.taobao.org/function-bind/download/function-bind-1.1.1.tgz",
             "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
         },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+        },
         "gauge": {
             "version": "2.7.4",
             "resolved": "http://registry.npm.taobao.org/gauge/download/gauge-2.7.4.tgz",
@@ -5207,26 +5458,6 @@
                 }
             }
         },
-        "gulp-angular-templatecache": {
-            "version": "2.0.0",
-            "resolved": "http://registry.npm.taobao.org/gulp-angular-templatecache/download/gulp-angular-templatecache-2.0.0.tgz",
-            "integrity": "sha1-KbQHHuVXRIHAaaFivOiWdTTxcVU=",
-            "requires": {
-                "event-stream": "3.3.2",
-                "gulp-concat": "2.6.0",
-                "gulp-footer": "1.0.5",
-                "gulp-header": "1.8.2",
-                "gulp-util": "3.0.7",
-                "jsesc": "2.2.0"
-            },
-            "dependencies": {
-                "jsesc": {
-                    "version": "2.2.0",
-                    "resolved": "http://registry.npm.taobao.org/jsesc/download/jsesc-2.2.0.tgz",
-                    "integrity": "sha1-w1qGE6OAbI7DuvwLDhlvAg96qwE="
-                }
-            }
-        },
         "gulp-clean": {
             "version": "0.3.2",
             "resolved": "http://registry.npm.taobao.org/gulp-clean/download/gulp-clean-0.3.2.tgz",
@@ -5412,89 +5643,6 @@
                     "resolved": "http://registry.npm.taobao.org/xtend/download/xtend-3.0.0.tgz",
                     "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
                 }
-            }
-        },
-        "gulp-concat": {
-            "version": "2.6.0",
-            "resolved": "http://registry.npm.taobao.org/gulp-concat/download/gulp-concat-2.6.0.tgz",
-            "integrity": "sha1-WFz7EVQR80h3MTEUBWa2qBxpy5E=",
-            "requires": {
-                "concat-with-sourcemaps": "1.0.4",
-                "gulp-util": "3.0.7",
-                "through2": "0.6.5"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "http://registry.npm.taobao.org/isarray/download/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "http://registry.npm.taobao.org/readable-stream/download/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "http://registry.npm.taobao.org/through2/download/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                }
-            }
-        },
-        "gulp-file-include": {
-            "version": "0.13.7",
-            "resolved": "http://registry.npm.taobao.org/gulp-file-include/download/gulp-file-include-0.13.7.tgz",
-            "integrity": "sha1-IYNbKxVQkG0cMScN+uQF/QYwfM4=",
-            "requires": {
-                "balanced-match": "0.2.1",
-                "concat-stream": "1.6.0",
-                "extend": "3.0.1",
-                "flatnest": "1.0.0",
-                "gulp-util": "3.0.7",
-                "through2": "2.0.1"
-            },
-            "dependencies": {
-                "balanced-match": {
-                    "version": "0.2.1",
-                    "resolved": "http://registry.npm.taobao.org/balanced-match/download/balanced-match-0.2.1.tgz",
-                    "integrity": "sha1-e8ZYtL7WHu5CStdPdfXD4sTfPMc="
-                }
-            }
-        },
-        "gulp-footer": {
-            "version": "1.0.5",
-            "resolved": "http://registry.npm.taobao.org/gulp-footer/download/gulp-footer-1.0.5.tgz",
-            "integrity": "sha1-6Eynd+Jmvnu8LUXS3w5+uo36PlQ=",
-            "requires": {
-                "event-stream": "3.3.2",
-                "gulp-util": "3.0.7",
-                "lodash.assign": "4.2.0"
-            }
-        },
-        "gulp-header": {
-            "version": "1.8.2",
-            "resolved": "http://registry.npm.taobao.org/gulp-header/download/gulp-header-1.8.2.tgz",
-            "integrity": "sha1-OrIi9TcZ0tA9gdkTQlL+fVJCWqQ=",
-            "requires": {
-                "concat-with-sourcemaps": "1.0.4",
-                "gulp-util": "3.0.7",
-                "object-assign": "4.1.1",
-                "through2": "2.0.1"
             }
         },
         "gulp-less": {
@@ -5816,17 +5964,6 @@
                 }
             }
         },
-        "gulp-open": {
-            "version": "2.0.0",
-            "resolved": "http://registry.npm.taobao.org/gulp-open/download/gulp-open-2.0.0.tgz",
-            "integrity": "sha1-oW9n6VzqiyBhtjo7jDibxVm44c4=",
-            "requires": {
-                "colors": "1.1.2",
-                "gulp-util": "3.0.7",
-                "open": "0.0.5",
-                "through2": "2.0.1"
-            }
-        },
         "gulp-plumber": {
             "version": "1.1.0",
             "resolved": "http://registry.npm.taobao.org/gulp-plumber/download/gulp-plumber-1.1.0.tgz",
@@ -5909,60 +6046,6 @@
                 }
             }
         },
-        "gulp-uglify": {
-            "version": "1.5.4",
-            "resolved": "http://registry.npm.taobao.org/gulp-uglify/download/gulp-uglify-1.5.4.tgz",
-            "integrity": "sha1-UkeI2HZm0J+dDCH7IXf5ADmmWMk=",
-            "requires": {
-                "deap": "1.0.0",
-                "fancy-log": "1.3.0",
-                "gulp-util": "3.0.7",
-                "isobject": "2.1.0",
-                "through2": "2.0.1",
-                "uglify-js": "2.6.4",
-                "uglify-save-license": "0.4.1",
-                "vinyl-sourcemaps-apply": "0.2.1"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "1.2.1",
-                    "resolved": "http://registry.npm.taobao.org/camelcase/download/camelcase-1.2.1.tgz",
-                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-                },
-                "uglify-js": {
-                    "version": "2.6.4",
-                    "resolved": "http://registry.npm.taobao.org/uglify-js/download/uglify-js-2.6.4.tgz",
-                    "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
-                    "requires": {
-                        "async": "0.2.10",
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
-                    }
-                },
-                "yargs": {
-                    "version": "3.10.0",
-                    "resolved": "http://registry.npm.taobao.org/yargs/download/yargs-3.10.0.tgz",
-                    "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                    "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
-                        "window-size": "0.1.0"
-                    }
-                }
-            }
-        },
-        "gulp-uglifycss": {
-            "version": "1.0.6",
-            "resolved": "http://registry.npm.taobao.org/gulp-uglifycss/download/gulp-uglifycss-1.0.6.tgz",
-            "integrity": "sha1-5RRTUv4KG8lGGIrR8FXdms+gmWA=",
-            "requires": {
-                "gulp-util": "3.0.7",
-                "through2": "2.0.1",
-                "uglifycss": "0.0.27"
-            }
-        },
         "gulp-util": {
             "version": "3.0.7",
             "resolved": "http://registry.npm.taobao.org/gulp-util/download/gulp-util-3.0.7.tgz",
@@ -6018,6 +6101,24 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "requires": {
                 "glogg": "1.0.0"
+            }
+        },
+        "happypack": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/happypack/-/happypack-4.0.1.tgz",
+            "integrity": "sha1-1xplINE8Hd9sxcoEDP4icRy6Ugk=",
+            "requires": {
+                "async": "1.5.0",
+                "json-stringify-safe": "5.0.1",
+                "loader-utils": "1.1.0",
+                "serialize-error": "2.1.0"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+                    "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM="
+                }
             }
         },
         "har-schema": {
@@ -6193,6 +6294,19 @@
             "resolved": "http://registry.npm.taobao.org/htmlescape/download/htmlescape-1.1.1.tgz",
             "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
         },
+        "htmlparser2": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+            "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+            "requires": {
+                "domelementtype": "1.3.0",
+                "domhandler": "2.4.1",
+                "domutils": "1.7.0",
+                "entities": "1.1.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+            }
+        },
         "http-errors": {
             "version": "1.3.1",
             "resolved": "http://registry.npm.taobao.org/http-errors/download/http-errors-1.3.1.tgz",
@@ -6280,6 +6394,11 @@
             "version": "1.1.8",
             "resolved": "http://registry.npm.taobao.org/ieee754/download/ieee754-1.1.8.tgz",
             "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+        },
+        "ignore": {
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+            "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
         },
         "image-size": {
             "version": "0.5.5",
@@ -6612,6 +6731,19 @@
             "resolved": "http://registry.npm.taobao.org/is-object/download/is-object-1.0.1.tgz",
             "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
         },
+        "is-path-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+        },
+        "is-path-in-cwd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+            "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+            "requires": {
+                "is-path-inside": "1.0.0"
+            }
+        },
         "is-path-inside": {
             "version": "1.0.0",
             "resolved": "http://registry.npm.taobao.org/is-path-inside/download/is-path-inside-1.0.0.tgz",
@@ -6667,6 +6799,11 @@
             "requires": {
                 "is-unc-path": "0.1.2"
             }
+        },
+        "is-resolvable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+            "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
         },
         "is-retry-allowed": {
             "version": "1.1.0",
@@ -6811,6 +6948,11 @@
                 "jsonify": "0.0.0"
             }
         },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "http://registry.npm.taobao.org/json-stringify-safe/download/json-stringify-safe-5.0.1.tgz",
@@ -6856,6 +6998,11 @@
                     "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                 }
             }
+        },
+        "junk": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
+            "integrity": "sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI="
         },
         "kind-of": {
             "version": "3.2.2",
@@ -7068,6 +7215,52 @@
                 }
             }
         },
+        "loader-fs-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
+            "integrity": "sha1-VuC/CL2XCLJqdltoUJhAyN7J/bw=",
+            "requires": {
+                "find-cache-dir": "0.1.1",
+                "mkdirp": "0.5.1"
+            },
+            "dependencies": {
+                "find-cache-dir": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+                    "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+                    "requires": {
+                        "commondir": "1.0.1",
+                        "mkdirp": "0.5.1",
+                        "pkg-dir": "1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "requires": {
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "pkg-dir": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+                    "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+                    "requires": {
+                        "find-up": "1.1.2"
+                    }
+                }
+            }
+        },
         "loader-runner": {
             "version": "2.3.0",
             "resolved": "http://registry.npm.taobao.org/loader-runner/download/loader-runner-2.3.0.tgz",
@@ -7134,6 +7327,15 @@
                 "lodash._bindcallback": "3.0.1",
                 "lodash._isiterateecall": "3.0.9",
                 "lodash.restparam": "3.6.1"
+            }
+        },
+        "lodash._createcompounder": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
+            "integrity": "sha1-XdLLVTctbnDg4jkvsjBNZjEJEHU=",
+            "requires": {
+                "lodash.deburr": "3.2.0",
+                "lodash.words": "3.2.0"
             }
         },
         "lodash._escapehtmlchar": {
@@ -7242,6 +7444,14 @@
             "version": "4.5.0",
             "resolved": "http://registry.npm.taobao.org/lodash.clonedeep/download/lodash.clonedeep-4.5.0.tgz",
             "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+        },
+        "lodash.deburr": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
+            "integrity": "sha1-baj1QzSjZqfPTEx2742Aqhs2XtU=",
+            "requires": {
+                "lodash._root": "3.0.1"
+            }
         },
         "lodash.defaults": {
             "version": "2.4.1",
@@ -7410,6 +7620,14 @@
                 }
             }
         },
+        "lodash.words": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz",
+            "integrity": "sha1-TiqGSbwIdFsXxpWxo86P7llmI7M=",
+            "requires": {
+                "lodash._root": "3.0.1"
+            }
+        },
         "log-symbols": {
             "version": "1.0.2",
             "resolved": "http://registry.npm.taobao.org/log-symbols/download/log-symbols-1.0.2.tgz",
@@ -7487,15 +7705,21 @@
             "resolved": "http://registry.npm.taobao.org/map-obj/download/map-obj-1.0.1.tgz",
             "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         },
-        "map-stream": {
-            "version": "0.1.0",
-            "resolved": "http://registry.npm.taobao.org/map-stream/download/map-stream-0.1.0.tgz",
-            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
-        },
         "math-expression-evaluator": {
             "version": "1.2.17",
             "resolved": "http://registry.npm.taobao.org/math-expression-evaluator/download/math-expression-evaluator-1.2.17.tgz",
             "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
+        },
+        "maximatch": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
+            "integrity": "sha1-hs2NawTJ8wfAWmuUGZBtA2D7E6I=",
+            "requires": {
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4"
+            }
         },
         "md5": {
             "version": "2.2.1",
@@ -7807,6 +8031,11 @@
             "resolved": "http://registry.npm.taobao.org/natives/download/natives-1.1.0.tgz",
             "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE="
         },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+        },
         "ncp": {
             "version": "1.0.1",
             "resolved": "http://registry.npm.taobao.org/ncp/download/ncp-1.0.1.tgz",
@@ -7992,6 +8221,11 @@
                 }
             }
         },
+        "node-uuid": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+            "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
         "node.extend": {
             "version": "1.1.6",
             "resolved": "http://registry.npm.taobao.org/node.extend/download/node.extend-1.1.6.tgz",
@@ -8041,6 +8275,3861 @@
                 "prepend-http": "1.0.4",
                 "query-string": "4.3.4",
                 "sort-keys": "1.1.2"
+            }
+        },
+        "npm": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-5.8.0.tgz",
+            "integrity": "sha512-DowXzQwtSWDtbAjuWecuEiismR0VdNEYaL3VxNTYTdW6AGkYxfGk9LUZ/rt6etEyiH4IEk95HkJeGfXE5Rz9xQ==",
+            "requires": {
+                "JSONStream": "1.3.2",
+                "abbrev": "1.1.1",
+                "ansi-regex": "3.0.0",
+                "ansicolors": "0.3.2",
+                "ansistyles": "0.1.3",
+                "aproba": "1.2.0",
+                "archy": "1.0.0",
+                "bin-links": "1.1.0",
+                "bluebird": "3.5.1",
+                "cacache": "10.0.4",
+                "call-limit": "1.1.0",
+                "chownr": "1.0.1",
+                "cli-table2": "0.2.0",
+                "cmd-shim": "2.0.2",
+                "columnify": "1.5.4",
+                "config-chain": "1.1.11",
+                "debuglog": "1.0.1",
+                "detect-indent": "5.0.0",
+                "detect-newline": "2.1.0",
+                "dezalgo": "1.0.3",
+                "editor": "1.0.0",
+                "find-npm-prefix": "1.0.2",
+                "fs-vacuum": "1.2.10",
+                "fs-write-stream-atomic": "1.0.10",
+                "gentle-fs": "2.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "has-unicode": "2.0.1",
+                "hosted-git-info": "2.6.0",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "ini": "1.3.5",
+                "init-package-json": "1.10.3",
+                "is-cidr": "1.0.0",
+                "json-parse-better-errors": "1.0.1",
+                "lazy-property": "1.0.0",
+                "libcipm": "1.6.0",
+                "libnpx": "10.0.1",
+                "lockfile": "1.0.3",
+                "lodash._baseindexof": "3.1.0",
+                "lodash._baseuniq": "4.6.0",
+                "lodash._bindcallback": "3.0.1",
+                "lodash._cacheindexof": "3.0.2",
+                "lodash._createcache": "3.1.2",
+                "lodash._getnative": "3.9.1",
+                "lodash.clonedeep": "4.5.0",
+                "lodash.restparam": "3.6.1",
+                "lodash.union": "4.6.0",
+                "lodash.uniq": "4.5.0",
+                "lodash.without": "4.4.0",
+                "lru-cache": "4.1.1",
+                "meant": "1.0.1",
+                "mississippi": "3.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "nopt": "4.0.1",
+                "normalize-package-data": "2.4.0",
+                "npm-cache-filename": "1.0.2",
+                "npm-install-checks": "3.0.0",
+                "npm-lifecycle": "2.0.1",
+                "npm-package-arg": "6.0.0",
+                "npm-packlist": "1.1.10",
+                "npm-profile": "3.0.1",
+                "npm-registry-client": "8.5.1",
+                "npm-user-validate": "1.0.0",
+                "npmlog": "4.1.2",
+                "once": "1.4.0",
+                "opener": "1.4.3",
+                "osenv": "0.1.5",
+                "pacote": "7.6.1",
+                "path-is-inside": "1.0.2",
+                "promise-inflight": "1.0.1",
+                "qrcode-terminal": "0.11.0",
+                "query-string": "5.1.0",
+                "qw": "1.0.1",
+                "read": "1.0.7",
+                "read-cmd-shim": "1.0.1",
+                "read-installed": "4.0.3",
+                "read-package-json": "2.0.13",
+                "read-package-tree": "5.1.6",
+                "readable-stream": "2.3.5",
+                "readdir-scoped-modules": "1.0.2",
+                "request": "2.83.0",
+                "retry": "0.10.1",
+                "rimraf": "2.6.2",
+                "safe-buffer": "5.1.1",
+                "semver": "5.5.0",
+                "sha": "2.0.1",
+                "slide": "1.1.6",
+                "sorted-object": "2.0.1",
+                "sorted-union-stream": "2.1.3",
+                "ssri": "5.2.4",
+                "strip-ansi": "4.0.0",
+                "tar": "4.4.0",
+                "text-table": "0.2.0",
+                "uid-number": "0.0.6",
+                "umask": "1.1.0",
+                "unique-filename": "1.1.0",
+                "unpipe": "1.0.0",
+                "update-notifier": "2.3.0",
+                "uuid": "3.2.1",
+                "validate-npm-package-license": "3.0.1",
+                "validate-npm-package-name": "3.0.0",
+                "which": "1.3.0",
+                "worker-farm": "1.5.4",
+                "wrappy": "1.0.2",
+                "write-file-atomic": "2.3.0"
+            },
+            "dependencies": {
+                "JSONStream": {
+                    "version": "1.3.2",
+                    "bundled": true,
+                    "requires": {
+                        "jsonparse": "1.3.1",
+                        "through": "2.3.8"
+                    },
+                    "dependencies": {
+                        "jsonparse": {
+                            "version": "1.3.1",
+                            "bundled": true
+                        },
+                        "through": {
+                            "version": "2.3.8",
+                            "bundled": true
+                        }
+                    }
+                },
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "bundled": true
+                },
+                "ansicolors": {
+                    "version": "0.3.2",
+                    "bundled": true
+                },
+                "ansistyles": {
+                    "version": "0.1.3",
+                    "bundled": true
+                },
+                "aproba": {
+                    "version": "1.2.0",
+                    "bundled": true
+                },
+                "archy": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "bin-links": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "bluebird": "3.5.1",
+                        "cmd-shim": "2.0.2",
+                        "fs-write-stream-atomic": "1.0.10",
+                        "gentle-fs": "2.0.1",
+                        "graceful-fs": "4.1.11",
+                        "slide": "1.1.6"
+                    }
+                },
+                "bluebird": {
+                    "version": "3.5.1",
+                    "bundled": true
+                },
+                "cacache": {
+                    "version": "10.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "bluebird": "3.5.1",
+                        "chownr": "1.0.1",
+                        "glob": "7.1.2",
+                        "graceful-fs": "4.1.11",
+                        "lru-cache": "4.1.1",
+                        "mississippi": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "move-concurrently": "1.0.1",
+                        "promise-inflight": "1.0.1",
+                        "rimraf": "2.6.2",
+                        "ssri": "5.2.4",
+                        "unique-filename": "1.1.0",
+                        "y18n": "4.0.0"
+                    },
+                    "dependencies": {
+                        "mississippi": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "concat-stream": "1.6.1",
+                                "duplexify": "3.5.4",
+                                "end-of-stream": "1.4.1",
+                                "flush-write-stream": "1.0.2",
+                                "from2": "2.3.0",
+                                "parallel-transform": "1.1.0",
+                                "pump": "2.0.1",
+                                "pumpify": "1.4.0",
+                                "stream-each": "1.2.2",
+                                "through2": "2.0.3"
+                            },
+                            "dependencies": {
+                                "concat-stream": {
+                                    "version": "1.6.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "inherits": "2.0.3",
+                                        "readable-stream": "2.3.5",
+                                        "typedarray": "0.0.6"
+                                    },
+                                    "dependencies": {
+                                        "typedarray": {
+                                            "version": "0.0.6",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "duplexify": {
+                                    "version": "3.5.4",
+                                    "bundled": true,
+                                    "requires": {
+                                        "end-of-stream": "1.4.1",
+                                        "inherits": "2.0.3",
+                                        "readable-stream": "2.3.5",
+                                        "stream-shift": "1.0.0"
+                                    },
+                                    "dependencies": {
+                                        "stream-shift": {
+                                            "version": "1.0.0",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "end-of-stream": {
+                                    "version": "1.4.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "once": "1.4.0"
+                                    }
+                                },
+                                "flush-write-stream": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "inherits": "2.0.3",
+                                        "readable-stream": "2.3.5"
+                                    }
+                                },
+                                "from2": {
+                                    "version": "2.3.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "inherits": "2.0.3",
+                                        "readable-stream": "2.3.5"
+                                    }
+                                },
+                                "parallel-transform": {
+                                    "version": "1.1.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "cyclist": "0.2.2",
+                                        "inherits": "2.0.3",
+                                        "readable-stream": "2.3.5"
+                                    },
+                                    "dependencies": {
+                                        "cyclist": {
+                                            "version": "0.2.2",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "pump": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "end-of-stream": "1.4.1",
+                                        "once": "1.4.0"
+                                    }
+                                },
+                                "pumpify": {
+                                    "version": "1.4.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "duplexify": "3.5.4",
+                                        "inherits": "2.0.3",
+                                        "pump": "2.0.1"
+                                    }
+                                },
+                                "stream-each": {
+                                    "version": "1.2.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "end-of-stream": "1.4.1",
+                                        "stream-shift": "1.0.0"
+                                    },
+                                    "dependencies": {
+                                        "stream-shift": {
+                                            "version": "1.0.0",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "through2": {
+                                    "version": "2.0.3",
+                                    "bundled": true,
+                                    "requires": {
+                                        "readable-stream": "2.3.5",
+                                        "xtend": "4.0.1"
+                                    },
+                                    "dependencies": {
+                                        "xtend": {
+                                            "version": "4.0.1",
+                                            "bundled": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "y18n": {
+                            "version": "4.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "call-limit": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "chownr": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "cli-table2": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "colors": "1.1.2",
+                        "lodash": "3.10.1",
+                        "string-width": "1.0.2"
+                    },
+                    "dependencies": {
+                        "colors": {
+                            "version": "1.1.2",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "lodash": {
+                            "version": "3.10.1",
+                            "bundled": true
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
+                            },
+                            "dependencies": {
+                                "code-point-at": {
+                                    "version": "1.1.0",
+                                    "bundled": true
+                                },
+                                "is-fullwidth-code-point": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "number-is-nan": "1.0.1"
+                                    },
+                                    "dependencies": {
+                                        "number-is-nan": {
+                                            "version": "1.0.1",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "strip-ansi": {
+                                    "version": "3.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "ansi-regex": "2.1.1"
+                                    },
+                                    "dependencies": {
+                                        "ansi-regex": {
+                                            "version": "2.1.1",
+                                            "bundled": true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "cmd-shim": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "mkdirp": "0.5.1"
+                    }
+                },
+                "columnify": {
+                    "version": "1.5.4",
+                    "bundled": true,
+                    "requires": {
+                        "strip-ansi": "3.0.1",
+                        "wcwidth": "1.0.1"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            },
+                            "dependencies": {
+                                "ansi-regex": {
+                                    "version": "2.1.1",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "wcwidth": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "defaults": "1.0.3"
+                            },
+                            "dependencies": {
+                                "defaults": {
+                                    "version": "1.0.3",
+                                    "bundled": true,
+                                    "requires": {
+                                        "clone": "1.0.2"
+                                    },
+                                    "dependencies": {
+                                        "clone": {
+                                            "version": "1.0.2",
+                                            "bundled": true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "config-chain": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "requires": {
+                        "ini": "1.3.5",
+                        "proto-list": "1.2.4"
+                    },
+                    "dependencies": {
+                        "proto-list": {
+                            "version": "1.2.4",
+                            "bundled": true
+                        }
+                    }
+                },
+                "debuglog": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "detect-indent": {
+                    "version": "5.0.0",
+                    "bundled": true
+                },
+                "detect-newline": {
+                    "version": "2.1.0",
+                    "bundled": true
+                },
+                "dezalgo": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "asap": "2.0.5",
+                        "wrappy": "1.0.2"
+                    },
+                    "dependencies": {
+                        "asap": {
+                            "version": "2.0.5",
+                            "bundled": true
+                        }
+                    }
+                },
+                "editor": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "find-npm-prefix": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "fs-vacuum": {
+                    "version": "1.2.10",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "path-is-inside": "1.0.2",
+                        "rimraf": "2.6.2"
+                    }
+                },
+                "fs-write-stream-atomic": {
+                    "version": "1.0.10",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "iferr": "0.1.5",
+                        "imurmurhash": "0.1.4",
+                        "readable-stream": "2.3.5"
+                    }
+                },
+                "gentle-fs": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "1.2.0",
+                        "fs-vacuum": "1.2.10",
+                        "graceful-fs": "4.1.11",
+                        "iferr": "0.1.5",
+                        "mkdirp": "0.5.1",
+                        "path-is-inside": "1.0.2",
+                        "read-cmd-shim": "1.0.1",
+                        "slide": "1.1.6"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    },
+                    "dependencies": {
+                        "fs.realpath": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "minimatch": {
+                            "version": "3.0.4",
+                            "bundled": true,
+                            "requires": {
+                                "brace-expansion": "1.1.8"
+                            },
+                            "dependencies": {
+                                "brace-expansion": {
+                                    "version": "1.1.8",
+                                    "bundled": true,
+                                    "requires": {
+                                        "balanced-match": "1.0.0",
+                                        "concat-map": "0.0.1"
+                                    },
+                                    "dependencies": {
+                                        "balanced-match": {
+                                            "version": "1.0.0",
+                                            "bundled": true
+                                        },
+                                        "concat-map": {
+                                            "version": "0.0.1",
+                                            "bundled": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "path-is-absolute": {
+                            "version": "1.0.1",
+                            "bundled": true
+                        }
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
+                "hosted-git-info": {
+                    "version": "2.6.0",
+                    "bundled": true
+                },
+                "iferr": {
+                    "version": "0.1.5",
+                    "bundled": true
+                },
+                "imurmurhash": {
+                    "version": "0.1.4",
+                    "bundled": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true
+                },
+                "init-package-json": {
+                    "version": "1.10.3",
+                    "bundled": true,
+                    "requires": {
+                        "glob": "7.1.2",
+                        "npm-package-arg": "6.0.0",
+                        "promzard": "0.3.0",
+                        "read": "1.0.7",
+                        "read-package-json": "2.0.13",
+                        "semver": "5.5.0",
+                        "validate-npm-package-license": "3.0.1",
+                        "validate-npm-package-name": "3.0.0"
+                    },
+                    "dependencies": {
+                        "promzard": {
+                            "version": "0.3.0",
+                            "bundled": true,
+                            "requires": {
+                                "read": "1.0.7"
+                            }
+                        }
+                    }
+                },
+                "is-cidr": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "cidr-regex": "1.0.6"
+                    },
+                    "dependencies": {
+                        "cidr-regex": {
+                            "version": "1.0.6",
+                            "bundled": true
+                        }
+                    }
+                },
+                "json-parse-better-errors": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "lazy-property": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "libcipm": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "requires": {
+                        "bin-links": "1.1.0",
+                        "bluebird": "3.5.1",
+                        "find-npm-prefix": "1.0.2",
+                        "graceful-fs": "4.1.11",
+                        "lock-verify": "2.0.0",
+                        "npm-lifecycle": "2.0.1",
+                        "npm-logical-tree": "1.2.1",
+                        "npm-package-arg": "6.0.0",
+                        "pacote": "7.6.1",
+                        "protoduck": "5.0.0",
+                        "read-package-json": "2.0.13",
+                        "rimraf": "2.6.2",
+                        "worker-farm": "1.5.4"
+                    },
+                    "dependencies": {
+                        "lock-verify": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "npm-package-arg": "5.1.2",
+                                "semver": "5.5.0"
+                            },
+                            "dependencies": {
+                                "npm-package-arg": {
+                                    "version": "5.1.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "hosted-git-info": "2.6.0",
+                                        "osenv": "0.1.5",
+                                        "semver": "5.5.0",
+                                        "validate-npm-package-name": "3.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "npm-logical-tree": {
+                            "version": "1.2.1",
+                            "bundled": true
+                        },
+                        "protoduck": {
+                            "version": "5.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "genfun": "4.0.1"
+                            },
+                            "dependencies": {
+                                "genfun": {
+                                    "version": "4.0.1",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "worker-farm": {
+                            "version": "1.5.4",
+                            "bundled": true,
+                            "requires": {
+                                "errno": "0.1.7",
+                                "xtend": "4.0.1"
+                            },
+                            "dependencies": {
+                                "errno": {
+                                    "version": "0.1.7",
+                                    "bundled": true,
+                                    "requires": {
+                                        "prr": "1.0.1"
+                                    },
+                                    "dependencies": {
+                                        "prr": {
+                                            "version": "1.0.1",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "xtend": {
+                                    "version": "4.0.1",
+                                    "bundled": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "libnpx": {
+                    "version": "10.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "dotenv": "5.0.1",
+                        "npm-package-arg": "6.0.0",
+                        "rimraf": "2.6.2",
+                        "safe-buffer": "5.1.1",
+                        "update-notifier": "2.3.0",
+                        "which": "1.3.0",
+                        "y18n": "4.0.0",
+                        "yargs": "11.0.0"
+                    },
+                    "dependencies": {
+                        "dotenv": {
+                            "version": "5.0.1",
+                            "bundled": true
+                        },
+                        "y18n": {
+                            "version": "4.0.0",
+                            "bundled": true
+                        },
+                        "yargs": {
+                            "version": "11.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "cliui": "4.0.0",
+                                "decamelize": "1.2.0",
+                                "find-up": "2.1.0",
+                                "get-caller-file": "1.0.2",
+                                "os-locale": "2.1.0",
+                                "require-directory": "2.1.1",
+                                "require-main-filename": "1.0.1",
+                                "set-blocking": "2.0.0",
+                                "string-width": "2.1.1",
+                                "which-module": "2.0.0",
+                                "y18n": "3.2.1",
+                                "yargs-parser": "9.0.2"
+                            },
+                            "dependencies": {
+                                "cliui": {
+                                    "version": "4.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "string-width": "2.1.1",
+                                        "strip-ansi": "4.0.0",
+                                        "wrap-ansi": "2.1.0"
+                                    },
+                                    "dependencies": {
+                                        "wrap-ansi": {
+                                            "version": "2.1.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "string-width": "1.0.2",
+                                                "strip-ansi": "3.0.1"
+                                            },
+                                            "dependencies": {
+                                                "string-width": {
+                                                    "version": "1.0.2",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "code-point-at": "1.1.0",
+                                                        "is-fullwidth-code-point": "1.0.0",
+                                                        "strip-ansi": "3.0.1"
+                                                    },
+                                                    "dependencies": {
+                                                        "code-point-at": {
+                                                            "version": "1.1.0",
+                                                            "bundled": true
+                                                        },
+                                                        "is-fullwidth-code-point": {
+                                                            "version": "1.0.0",
+                                                            "bundled": true,
+                                                            "requires": {
+                                                                "number-is-nan": "1.0.1"
+                                                            },
+                                                            "dependencies": {
+                                                                "number-is-nan": {
+                                                                    "version": "1.0.1",
+                                                                    "bundled": true
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "strip-ansi": {
+                                                    "version": "3.0.1",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "ansi-regex": "2.1.1"
+                                                    },
+                                                    "dependencies": {
+                                                        "ansi-regex": {
+                                                            "version": "2.1.1",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "decamelize": {
+                                    "version": "1.2.0",
+                                    "bundled": true
+                                },
+                                "find-up": {
+                                    "version": "2.1.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "locate-path": "2.0.0"
+                                    },
+                                    "dependencies": {
+                                        "locate-path": {
+                                            "version": "2.0.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "p-locate": "2.0.0",
+                                                "path-exists": "3.0.0"
+                                            },
+                                            "dependencies": {
+                                                "p-locate": {
+                                                    "version": "2.0.0",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "p-limit": "1.2.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "p-limit": {
+                                                            "version": "1.2.0",
+                                                            "bundled": true,
+                                                            "requires": {
+                                                                "p-try": "1.0.0"
+                                                            },
+                                                            "dependencies": {
+                                                                "p-try": {
+                                                                    "version": "1.0.0",
+                                                                    "bundled": true
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "path-exists": {
+                                                    "version": "3.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "get-caller-file": {
+                                    "version": "1.0.2",
+                                    "bundled": true
+                                },
+                                "os-locale": {
+                                    "version": "2.1.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "execa": "0.7.0",
+                                        "lcid": "1.0.0",
+                                        "mem": "1.1.0"
+                                    },
+                                    "dependencies": {
+                                        "execa": {
+                                            "version": "0.7.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "cross-spawn": "5.1.0",
+                                                "get-stream": "3.0.0",
+                                                "is-stream": "1.1.0",
+                                                "npm-run-path": "2.0.2",
+                                                "p-finally": "1.0.0",
+                                                "signal-exit": "3.0.2",
+                                                "strip-eof": "1.0.0"
+                                            },
+                                            "dependencies": {
+                                                "cross-spawn": {
+                                                    "version": "5.1.0",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "lru-cache": "4.1.1",
+                                                        "shebang-command": "1.2.0",
+                                                        "which": "1.3.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "shebang-command": {
+                                                            "version": "1.2.0",
+                                                            "bundled": true,
+                                                            "requires": {
+                                                                "shebang-regex": "1.0.0"
+                                                            },
+                                                            "dependencies": {
+                                                                "shebang-regex": {
+                                                                    "version": "1.0.0",
+                                                                    "bundled": true
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "get-stream": {
+                                                    "version": "3.0.0",
+                                                    "bundled": true
+                                                },
+                                                "is-stream": {
+                                                    "version": "1.1.0",
+                                                    "bundled": true
+                                                },
+                                                "npm-run-path": {
+                                                    "version": "2.0.2",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "path-key": "2.0.1"
+                                                    },
+                                                    "dependencies": {
+                                                        "path-key": {
+                                                            "version": "2.0.1",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                },
+                                                "p-finally": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                },
+                                                "signal-exit": {
+                                                    "version": "3.0.2",
+                                                    "bundled": true
+                                                },
+                                                "strip-eof": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        },
+                                        "lcid": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "invert-kv": "1.0.0"
+                                            },
+                                            "dependencies": {
+                                                "invert-kv": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        },
+                                        "mem": {
+                                            "version": "1.1.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "mimic-fn": "1.2.0"
+                                            },
+                                            "dependencies": {
+                                                "mimic-fn": {
+                                                    "version": "1.2.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "require-directory": {
+                                    "version": "2.1.1",
+                                    "bundled": true
+                                },
+                                "require-main-filename": {
+                                    "version": "1.0.1",
+                                    "bundled": true
+                                },
+                                "set-blocking": {
+                                    "version": "2.0.0",
+                                    "bundled": true
+                                },
+                                "string-width": {
+                                    "version": "2.1.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-fullwidth-code-point": "2.0.0",
+                                        "strip-ansi": "4.0.0"
+                                    },
+                                    "dependencies": {
+                                        "is-fullwidth-code-point": {
+                                            "version": "2.0.0",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "which-module": {
+                                    "version": "2.0.0",
+                                    "bundled": true
+                                },
+                                "y18n": {
+                                    "version": "3.2.1",
+                                    "bundled": true
+                                },
+                                "yargs-parser": {
+                                    "version": "9.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "camelcase": "4.1.0"
+                                    },
+                                    "dependencies": {
+                                        "camelcase": {
+                                            "version": "4.1.0",
+                                            "bundled": true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "lockfile": {
+                    "version": "1.0.3",
+                    "bundled": true
+                },
+                "lodash._baseindexof": {
+                    "version": "3.1.0",
+                    "bundled": true
+                },
+                "lodash._baseuniq": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "requires": {
+                        "lodash._createset": "4.0.3",
+                        "lodash._root": "3.0.1"
+                    },
+                    "dependencies": {
+                        "lodash._createset": {
+                            "version": "4.0.3",
+                            "bundled": true
+                        },
+                        "lodash._root": {
+                            "version": "3.0.1",
+                            "bundled": true
+                        }
+                    }
+                },
+                "lodash._bindcallback": {
+                    "version": "3.0.1",
+                    "bundled": true
+                },
+                "lodash._cacheindexof": {
+                    "version": "3.0.2",
+                    "bundled": true
+                },
+                "lodash._createcache": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "lodash._getnative": "3.9.1"
+                    }
+                },
+                "lodash._getnative": {
+                    "version": "3.9.1",
+                    "bundled": true
+                },
+                "lodash.clonedeep": {
+                    "version": "4.5.0",
+                    "bundled": true
+                },
+                "lodash.restparam": {
+                    "version": "3.6.1",
+                    "bundled": true
+                },
+                "lodash.union": {
+                    "version": "4.6.0",
+                    "bundled": true
+                },
+                "lodash.uniq": {
+                    "version": "4.5.0",
+                    "bundled": true
+                },
+                "lodash.without": {
+                    "version": "4.4.0",
+                    "bundled": true
+                },
+                "lru-cache": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
+                    },
+                    "dependencies": {
+                        "pseudomap": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        },
+                        "yallist": {
+                            "version": "2.1.2",
+                            "bundled": true
+                        }
+                    }
+                },
+                "meant": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "mississippi": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "concat-stream": "1.6.1",
+                        "duplexify": "3.5.4",
+                        "end-of-stream": "1.4.1",
+                        "flush-write-stream": "1.0.2",
+                        "from2": "2.3.0",
+                        "parallel-transform": "1.1.0",
+                        "pump": "3.0.0",
+                        "pumpify": "1.4.0",
+                        "stream-each": "1.2.2",
+                        "through2": "2.0.3"
+                    },
+                    "dependencies": {
+                        "concat-stream": {
+                            "version": "1.6.1",
+                            "bundled": true,
+                            "requires": {
+                                "inherits": "2.0.3",
+                                "readable-stream": "2.3.5",
+                                "typedarray": "0.0.6"
+                            },
+                            "dependencies": {
+                                "typedarray": {
+                                    "version": "0.0.6",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "duplexify": {
+                            "version": "3.5.4",
+                            "bundled": true,
+                            "requires": {
+                                "end-of-stream": "1.4.1",
+                                "inherits": "2.0.3",
+                                "readable-stream": "2.3.5",
+                                "stream-shift": "1.0.0"
+                            },
+                            "dependencies": {
+                                "stream-shift": {
+                                    "version": "1.0.0",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "end-of-stream": {
+                            "version": "1.4.1",
+                            "bundled": true,
+                            "requires": {
+                                "once": "1.4.0"
+                            }
+                        },
+                        "flush-write-stream": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "inherits": "2.0.3",
+                                "readable-stream": "2.3.5"
+                            }
+                        },
+                        "from2": {
+                            "version": "2.3.0",
+                            "bundled": true,
+                            "requires": {
+                                "inherits": "2.0.3",
+                                "readable-stream": "2.3.5"
+                            }
+                        },
+                        "parallel-transform": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "cyclist": "0.2.2",
+                                "inherits": "2.0.3",
+                                "readable-stream": "2.3.5"
+                            },
+                            "dependencies": {
+                                "cyclist": {
+                                    "version": "0.2.2",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "pump": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "end-of-stream": "1.4.1",
+                                "once": "1.4.0"
+                            }
+                        },
+                        "pumpify": {
+                            "version": "1.4.0",
+                            "bundled": true,
+                            "requires": {
+                                "duplexify": "3.5.4",
+                                "inherits": "2.0.3",
+                                "pump": "2.0.1"
+                            },
+                            "dependencies": {
+                                "pump": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "end-of-stream": "1.4.1",
+                                        "once": "1.4.0"
+                                    }
+                                }
+                            }
+                        },
+                        "stream-each": {
+                            "version": "1.2.2",
+                            "bundled": true,
+                            "requires": {
+                                "end-of-stream": "1.4.1",
+                                "stream-shift": "1.0.0"
+                            },
+                            "dependencies": {
+                                "stream-shift": {
+                                    "version": "1.0.0",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "through2": {
+                            "version": "2.0.3",
+                            "bundled": true,
+                            "requires": {
+                                "readable-stream": "2.3.5",
+                                "xtend": "4.0.1"
+                            },
+                            "dependencies": {
+                                "xtend": {
+                                    "version": "4.0.1",
+                                    "bundled": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "0.0.8",
+                            "bundled": true
+                        }
+                    }
+                },
+                "move-concurrently": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "1.2.0",
+                        "copy-concurrently": "1.0.5",
+                        "fs-write-stream-atomic": "1.0.10",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.2",
+                        "run-queue": "1.0.3"
+                    },
+                    "dependencies": {
+                        "copy-concurrently": {
+                            "version": "1.0.5",
+                            "bundled": true,
+                            "requires": {
+                                "aproba": "1.2.0",
+                                "fs-write-stream-atomic": "1.0.10",
+                                "iferr": "0.1.5",
+                                "mkdirp": "0.5.1",
+                                "rimraf": "2.6.2",
+                                "run-queue": "1.0.3"
+                            }
+                        },
+                        "run-queue": {
+                            "version": "1.0.3",
+                            "bundled": true,
+                            "requires": {
+                                "aproba": "1.2.0"
+                            }
+                        }
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.5"
+                    }
+                },
+                "normalize-package-data": {
+                    "version": "2.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "hosted-git-info": "2.6.0",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.5.0",
+                        "validate-npm-package-license": "3.0.1"
+                    },
+                    "dependencies": {
+                        "is-builtin-module": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "builtin-modules": "1.1.1"
+                            },
+                            "dependencies": {
+                                "builtin-modules": {
+                                    "version": "1.1.1",
+                                    "bundled": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "npm-cache-filename": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "npm-install-checks": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "semver": "5.5.0"
+                    }
+                },
+                "npm-lifecycle": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "byline": "5.0.0",
+                        "graceful-fs": "4.1.11",
+                        "node-gyp": "3.6.2",
+                        "resolve-from": "4.0.0",
+                        "slide": "1.1.6",
+                        "uid-number": "0.0.6",
+                        "umask": "1.1.0",
+                        "which": "1.3.0"
+                    },
+                    "dependencies": {
+                        "byline": {
+                            "version": "5.0.0",
+                            "bundled": true
+                        },
+                        "node-gyp": {
+                            "version": "3.6.2",
+                            "bundled": true,
+                            "requires": {
+                                "fstream": "1.0.11",
+                                "glob": "7.1.2",
+                                "graceful-fs": "4.1.11",
+                                "minimatch": "3.0.4",
+                                "mkdirp": "0.5.1",
+                                "nopt": "3.0.6",
+                                "npmlog": "4.1.2",
+                                "osenv": "0.1.5",
+                                "request": "2.83.0",
+                                "rimraf": "2.6.2",
+                                "semver": "5.3.0",
+                                "tar": "2.2.1",
+                                "which": "1.3.0"
+                            },
+                            "dependencies": {
+                                "fstream": {
+                                    "version": "1.0.11",
+                                    "bundled": true,
+                                    "requires": {
+                                        "graceful-fs": "4.1.11",
+                                        "inherits": "2.0.3",
+                                        "mkdirp": "0.5.1",
+                                        "rimraf": "2.6.2"
+                                    }
+                                },
+                                "minimatch": {
+                                    "version": "3.0.4",
+                                    "bundled": true,
+                                    "requires": {
+                                        "brace-expansion": "1.1.11"
+                                    },
+                                    "dependencies": {
+                                        "brace-expansion": {
+                                            "version": "1.1.11",
+                                            "bundled": true,
+                                            "requires": {
+                                                "balanced-match": "1.0.0",
+                                                "concat-map": "0.0.1"
+                                            },
+                                            "dependencies": {
+                                                "balanced-match": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                },
+                                                "concat-map": {
+                                                    "version": "0.0.1",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "nopt": {
+                                    "version": "3.0.6",
+                                    "bundled": true,
+                                    "requires": {
+                                        "abbrev": "1.1.1"
+                                    }
+                                },
+                                "semver": {
+                                    "version": "5.3.0",
+                                    "bundled": true
+                                },
+                                "tar": {
+                                    "version": "2.2.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "block-stream": "0.0.9",
+                                        "fstream": "1.0.11",
+                                        "inherits": "2.0.3"
+                                    },
+                                    "dependencies": {
+                                        "block-stream": {
+                                            "version": "0.0.9",
+                                            "bundled": true,
+                                            "requires": {
+                                                "inherits": "2.0.3"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "resolve-from": {
+                            "version": "4.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "npm-package-arg": {
+                    "version": "6.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "hosted-git-info": "2.6.0",
+                        "osenv": "0.1.5",
+                        "semver": "5.5.0",
+                        "validate-npm-package-name": "3.0.0"
+                    }
+                },
+                "npm-packlist": {
+                    "version": "1.1.10",
+                    "bundled": true,
+                    "requires": {
+                        "ignore-walk": "3.0.1",
+                        "npm-bundled": "1.0.3"
+                    },
+                    "dependencies": {
+                        "ignore-walk": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "minimatch": "3.0.4"
+                            },
+                            "dependencies": {
+                                "minimatch": {
+                                    "version": "3.0.4",
+                                    "bundled": true,
+                                    "requires": {
+                                        "brace-expansion": "1.1.8"
+                                    },
+                                    "dependencies": {
+                                        "brace-expansion": {
+                                            "version": "1.1.8",
+                                            "bundled": true,
+                                            "requires": {
+                                                "balanced-match": "1.0.0",
+                                                "concat-map": "0.0.1"
+                                            },
+                                            "dependencies": {
+                                                "balanced-match": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                },
+                                                "concat-map": {
+                                                    "version": "0.0.1",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "npm-bundled": {
+                            "version": "1.0.3",
+                            "bundled": true
+                        }
+                    }
+                },
+                "npm-profile": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "1.2.0",
+                        "make-fetch-happen": "2.6.0"
+                    },
+                    "dependencies": {
+                        "make-fetch-happen": {
+                            "version": "2.6.0",
+                            "bundled": true,
+                            "requires": {
+                                "agentkeepalive": "3.3.0",
+                                "cacache": "10.0.4",
+                                "http-cache-semantics": "3.8.1",
+                                "http-proxy-agent": "2.0.0",
+                                "https-proxy-agent": "2.1.1",
+                                "lru-cache": "4.1.1",
+                                "mississippi": "1.3.1",
+                                "node-fetch-npm": "2.0.2",
+                                "promise-retry": "1.1.1",
+                                "socks-proxy-agent": "3.0.1",
+                                "ssri": "5.2.4"
+                            },
+                            "dependencies": {
+                                "agentkeepalive": {
+                                    "version": "3.3.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "humanize-ms": "1.2.1"
+                                    },
+                                    "dependencies": {
+                                        "humanize-ms": {
+                                            "version": "1.2.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "ms": "2.1.1"
+                                            },
+                                            "dependencies": {
+                                                "ms": {
+                                                    "version": "2.1.1",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "http-cache-semantics": {
+                                    "version": "3.8.1",
+                                    "bundled": true
+                                },
+                                "http-proxy-agent": {
+                                    "version": "2.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "agent-base": "4.2.0",
+                                        "debug": "2.6.9"
+                                    },
+                                    "dependencies": {
+                                        "agent-base": {
+                                            "version": "4.2.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "es6-promisify": "5.0.0"
+                                            },
+                                            "dependencies": {
+                                                "es6-promisify": {
+                                                    "version": "5.0.0",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "es6-promise": "4.2.4"
+                                                    },
+                                                    "dependencies": {
+                                                        "es6-promise": {
+                                                            "version": "4.2.4",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "debug": {
+                                            "version": "2.6.9",
+                                            "bundled": true,
+                                            "requires": {
+                                                "ms": "2.0.0"
+                                            },
+                                            "dependencies": {
+                                                "ms": {
+                                                    "version": "2.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "https-proxy-agent": {
+                                    "version": "2.1.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "agent-base": "4.2.0",
+                                        "debug": "3.1.0"
+                                    },
+                                    "dependencies": {
+                                        "agent-base": {
+                                            "version": "4.2.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "es6-promisify": "5.0.0"
+                                            },
+                                            "dependencies": {
+                                                "es6-promisify": {
+                                                    "version": "5.0.0",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "es6-promise": "4.2.4"
+                                                    },
+                                                    "dependencies": {
+                                                        "es6-promise": {
+                                                            "version": "4.2.4",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "debug": {
+                                            "version": "3.1.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "ms": "2.0.0"
+                                            },
+                                            "dependencies": {
+                                                "ms": {
+                                                    "version": "2.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "mississippi": {
+                                    "version": "1.3.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "concat-stream": "1.6.0",
+                                        "duplexify": "3.5.3",
+                                        "end-of-stream": "1.4.1",
+                                        "flush-write-stream": "1.0.2",
+                                        "from2": "2.3.0",
+                                        "parallel-transform": "1.1.0",
+                                        "pump": "1.0.3",
+                                        "pumpify": "1.4.0",
+                                        "stream-each": "1.2.2",
+                                        "through2": "2.0.3"
+                                    },
+                                    "dependencies": {
+                                        "concat-stream": {
+                                            "version": "1.6.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "inherits": "2.0.3",
+                                                "readable-stream": "2.3.5",
+                                                "typedarray": "0.0.6"
+                                            },
+                                            "dependencies": {
+                                                "typedarray": {
+                                                    "version": "0.0.6",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        },
+                                        "duplexify": {
+                                            "version": "3.5.3",
+                                            "bundled": true,
+                                            "requires": {
+                                                "end-of-stream": "1.4.1",
+                                                "inherits": "2.0.3",
+                                                "readable-stream": "2.3.5",
+                                                "stream-shift": "1.0.0"
+                                            },
+                                            "dependencies": {
+                                                "stream-shift": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        },
+                                        "end-of-stream": {
+                                            "version": "1.4.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "once": "1.4.0"
+                                            }
+                                        },
+                                        "flush-write-stream": {
+                                            "version": "1.0.2",
+                                            "bundled": true,
+                                            "requires": {
+                                                "inherits": "2.0.3",
+                                                "readable-stream": "2.3.5"
+                                            }
+                                        },
+                                        "from2": {
+                                            "version": "2.3.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "inherits": "2.0.3",
+                                                "readable-stream": "2.3.5"
+                                            }
+                                        },
+                                        "parallel-transform": {
+                                            "version": "1.1.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "cyclist": "0.2.2",
+                                                "inherits": "2.0.3",
+                                                "readable-stream": "2.3.5"
+                                            },
+                                            "dependencies": {
+                                                "cyclist": {
+                                                    "version": "0.2.2",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        },
+                                        "pump": {
+                                            "version": "1.0.3",
+                                            "bundled": true,
+                                            "requires": {
+                                                "end-of-stream": "1.4.1",
+                                                "once": "1.4.0"
+                                            }
+                                        },
+                                        "pumpify": {
+                                            "version": "1.4.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "duplexify": "3.5.3",
+                                                "inherits": "2.0.3",
+                                                "pump": "2.0.1"
+                                            },
+                                            "dependencies": {
+                                                "pump": {
+                                                    "version": "2.0.1",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "end-of-stream": "1.4.1",
+                                                        "once": "1.4.0"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "stream-each": {
+                                            "version": "1.2.2",
+                                            "bundled": true,
+                                            "requires": {
+                                                "end-of-stream": "1.4.1",
+                                                "stream-shift": "1.0.0"
+                                            },
+                                            "dependencies": {
+                                                "stream-shift": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        },
+                                        "through2": {
+                                            "version": "2.0.3",
+                                            "bundled": true,
+                                            "requires": {
+                                                "readable-stream": "2.3.5",
+                                                "xtend": "4.0.1"
+                                            },
+                                            "dependencies": {
+                                                "xtend": {
+                                                    "version": "4.0.1",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "node-fetch-npm": {
+                                    "version": "2.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "encoding": "0.1.12",
+                                        "json-parse-better-errors": "1.0.1",
+                                        "safe-buffer": "5.1.1"
+                                    },
+                                    "dependencies": {
+                                        "encoding": {
+                                            "version": "0.1.12",
+                                            "bundled": true,
+                                            "requires": {
+                                                "iconv-lite": "0.4.19"
+                                            },
+                                            "dependencies": {
+                                                "iconv-lite": {
+                                                    "version": "0.4.19",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        },
+                                        "json-parse-better-errors": {
+                                            "version": "1.0.1",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "promise-retry": {
+                                    "version": "1.1.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "err-code": "1.1.2",
+                                        "retry": "0.10.1"
+                                    },
+                                    "dependencies": {
+                                        "err-code": {
+                                            "version": "1.1.2",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "socks-proxy-agent": {
+                                    "version": "3.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "agent-base": "4.2.0",
+                                        "socks": "1.1.10"
+                                    },
+                                    "dependencies": {
+                                        "agent-base": {
+                                            "version": "4.2.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "es6-promisify": "5.0.0"
+                                            },
+                                            "dependencies": {
+                                                "es6-promisify": {
+                                                    "version": "5.0.0",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "es6-promise": "4.2.4"
+                                                    },
+                                                    "dependencies": {
+                                                        "es6-promise": {
+                                                            "version": "4.2.4",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "socks": {
+                                            "version": "1.1.10",
+                                            "bundled": true,
+                                            "requires": {
+                                                "ip": "1.1.5",
+                                                "smart-buffer": "1.1.15"
+                                            },
+                                            "dependencies": {
+                                                "ip": {
+                                                    "version": "1.1.5",
+                                                    "bundled": true
+                                                },
+                                                "smart-buffer": {
+                                                    "version": "1.1.15",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "npm-registry-client": {
+                    "version": "8.5.1",
+                    "bundled": true,
+                    "requires": {
+                        "concat-stream": "1.6.1",
+                        "graceful-fs": "4.1.11",
+                        "normalize-package-data": "2.4.0",
+                        "npm-package-arg": "6.0.0",
+                        "npmlog": "4.1.2",
+                        "once": "1.4.0",
+                        "request": "2.83.0",
+                        "retry": "0.10.1",
+                        "safe-buffer": "5.1.1",
+                        "semver": "5.5.0",
+                        "slide": "1.1.6",
+                        "ssri": "5.2.4"
+                    },
+                    "dependencies": {
+                        "concat-stream": {
+                            "version": "1.6.1",
+                            "bundled": true,
+                            "requires": {
+                                "inherits": "2.0.3",
+                                "readable-stream": "2.3.5",
+                                "typedarray": "0.0.6"
+                            },
+                            "dependencies": {
+                                "typedarray": {
+                                    "version": "0.0.6",
+                                    "bundled": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "npm-user-validate": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    },
+                    "dependencies": {
+                        "are-we-there-yet": {
+                            "version": "1.1.4",
+                            "bundled": true,
+                            "requires": {
+                                "delegates": "1.0.0",
+                                "readable-stream": "2.3.5"
+                            },
+                            "dependencies": {
+                                "delegates": {
+                                    "version": "1.0.0",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "console-control-strings": {
+                            "version": "1.1.0",
+                            "bundled": true
+                        },
+                        "gauge": {
+                            "version": "2.7.4",
+                            "bundled": true,
+                            "requires": {
+                                "aproba": "1.2.0",
+                                "console-control-strings": "1.1.0",
+                                "has-unicode": "2.0.1",
+                                "object-assign": "4.1.1",
+                                "signal-exit": "3.0.2",
+                                "string-width": "1.0.2",
+                                "strip-ansi": "3.0.1",
+                                "wide-align": "1.1.2"
+                            },
+                            "dependencies": {
+                                "object-assign": {
+                                    "version": "4.1.1",
+                                    "bundled": true
+                                },
+                                "signal-exit": {
+                                    "version": "3.0.2",
+                                    "bundled": true
+                                },
+                                "string-width": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "code-point-at": "1.1.0",
+                                        "is-fullwidth-code-point": "1.0.0",
+                                        "strip-ansi": "3.0.1"
+                                    },
+                                    "dependencies": {
+                                        "code-point-at": {
+                                            "version": "1.1.0",
+                                            "bundled": true
+                                        },
+                                        "is-fullwidth-code-point": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "number-is-nan": "1.0.1"
+                                            },
+                                            "dependencies": {
+                                                "number-is-nan": {
+                                                    "version": "1.0.1",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "strip-ansi": {
+                                    "version": "3.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "ansi-regex": "2.1.1"
+                                    },
+                                    "dependencies": {
+                                        "ansi-regex": {
+                                            "version": "2.1.1",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "wide-align": {
+                                    "version": "1.1.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "string-width": "1.0.2"
+                                    }
+                                }
+                            }
+                        },
+                        "set-blocking": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "opener": {
+                    "version": "1.4.3",
+                    "bundled": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    },
+                    "dependencies": {
+                        "os-homedir": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        },
+                        "os-tmpdir": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        }
+                    }
+                },
+                "pacote": {
+                    "version": "7.6.1",
+                    "bundled": true,
+                    "requires": {
+                        "bluebird": "3.5.1",
+                        "cacache": "10.0.4",
+                        "get-stream": "3.0.0",
+                        "glob": "7.1.2",
+                        "lru-cache": "4.1.1",
+                        "make-fetch-happen": "2.6.0",
+                        "minimatch": "3.0.4",
+                        "mississippi": "3.0.0",
+                        "mkdirp": "0.5.1",
+                        "normalize-package-data": "2.4.0",
+                        "npm-package-arg": "6.0.0",
+                        "npm-packlist": "1.1.10",
+                        "npm-pick-manifest": "2.1.0",
+                        "osenv": "0.1.5",
+                        "promise-inflight": "1.0.1",
+                        "promise-retry": "1.1.1",
+                        "protoduck": "5.0.0",
+                        "rimraf": "2.6.2",
+                        "safe-buffer": "5.1.1",
+                        "semver": "5.5.0",
+                        "ssri": "5.2.4",
+                        "tar": "4.4.0",
+                        "unique-filename": "1.1.0",
+                        "which": "1.3.0"
+                    },
+                    "dependencies": {
+                        "get-stream": {
+                            "version": "3.0.0",
+                            "bundled": true
+                        },
+                        "make-fetch-happen": {
+                            "version": "2.6.0",
+                            "bundled": true,
+                            "requires": {
+                                "agentkeepalive": "3.4.0",
+                                "cacache": "10.0.4",
+                                "http-cache-semantics": "3.8.1",
+                                "http-proxy-agent": "2.1.0",
+                                "https-proxy-agent": "2.2.0",
+                                "lru-cache": "4.1.1",
+                                "mississippi": "1.3.1",
+                                "node-fetch-npm": "2.0.2",
+                                "promise-retry": "1.1.1",
+                                "socks-proxy-agent": "3.0.1",
+                                "ssri": "5.2.4"
+                            },
+                            "dependencies": {
+                                "agentkeepalive": {
+                                    "version": "3.4.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "humanize-ms": "1.2.1"
+                                    },
+                                    "dependencies": {
+                                        "humanize-ms": {
+                                            "version": "1.2.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "ms": "2.1.1"
+                                            },
+                                            "dependencies": {
+                                                "ms": {
+                                                    "version": "2.1.1",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "http-cache-semantics": {
+                                    "version": "3.8.1",
+                                    "bundled": true
+                                },
+                                "http-proxy-agent": {
+                                    "version": "2.1.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "agent-base": "4.2.0",
+                                        "debug": "3.1.0"
+                                    },
+                                    "dependencies": {
+                                        "agent-base": {
+                                            "version": "4.2.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "es6-promisify": "5.0.0"
+                                            },
+                                            "dependencies": {
+                                                "es6-promisify": {
+                                                    "version": "5.0.0",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "es6-promise": "4.2.4"
+                                                    },
+                                                    "dependencies": {
+                                                        "es6-promise": {
+                                                            "version": "4.2.4",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "debug": {
+                                            "version": "3.1.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "ms": "2.0.0"
+                                            },
+                                            "dependencies": {
+                                                "ms": {
+                                                    "version": "2.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "https-proxy-agent": {
+                                    "version": "2.2.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "agent-base": "4.2.0",
+                                        "debug": "3.1.0"
+                                    },
+                                    "dependencies": {
+                                        "agent-base": {
+                                            "version": "4.2.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "es6-promisify": "5.0.0"
+                                            },
+                                            "dependencies": {
+                                                "es6-promisify": {
+                                                    "version": "5.0.0",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "es6-promise": "4.2.4"
+                                                    },
+                                                    "dependencies": {
+                                                        "es6-promise": {
+                                                            "version": "4.2.4",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "debug": {
+                                            "version": "3.1.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "ms": "2.0.0"
+                                            },
+                                            "dependencies": {
+                                                "ms": {
+                                                    "version": "2.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "mississippi": {
+                                    "version": "1.3.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "concat-stream": "1.6.1",
+                                        "duplexify": "3.5.4",
+                                        "end-of-stream": "1.4.1",
+                                        "flush-write-stream": "1.0.2",
+                                        "from2": "2.3.0",
+                                        "parallel-transform": "1.1.0",
+                                        "pump": "1.0.3",
+                                        "pumpify": "1.4.0",
+                                        "stream-each": "1.2.2",
+                                        "through2": "2.0.3"
+                                    },
+                                    "dependencies": {
+                                        "concat-stream": {
+                                            "version": "1.6.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "inherits": "2.0.3",
+                                                "readable-stream": "2.3.5",
+                                                "typedarray": "0.0.6"
+                                            },
+                                            "dependencies": {
+                                                "typedarray": {
+                                                    "version": "0.0.6",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        },
+                                        "duplexify": {
+                                            "version": "3.5.4",
+                                            "bundled": true,
+                                            "requires": {
+                                                "end-of-stream": "1.4.1",
+                                                "inherits": "2.0.3",
+                                                "readable-stream": "2.3.5",
+                                                "stream-shift": "1.0.0"
+                                            },
+                                            "dependencies": {
+                                                "stream-shift": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        },
+                                        "end-of-stream": {
+                                            "version": "1.4.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "once": "1.4.0"
+                                            }
+                                        },
+                                        "flush-write-stream": {
+                                            "version": "1.0.2",
+                                            "bundled": true,
+                                            "requires": {
+                                                "inherits": "2.0.3",
+                                                "readable-stream": "2.3.5"
+                                            }
+                                        },
+                                        "from2": {
+                                            "version": "2.3.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "inherits": "2.0.3",
+                                                "readable-stream": "2.3.5"
+                                            }
+                                        },
+                                        "parallel-transform": {
+                                            "version": "1.1.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "cyclist": "0.2.2",
+                                                "inherits": "2.0.3",
+                                                "readable-stream": "2.3.5"
+                                            },
+                                            "dependencies": {
+                                                "cyclist": {
+                                                    "version": "0.2.2",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        },
+                                        "pump": {
+                                            "version": "1.0.3",
+                                            "bundled": true,
+                                            "requires": {
+                                                "end-of-stream": "1.4.1",
+                                                "once": "1.4.0"
+                                            }
+                                        },
+                                        "pumpify": {
+                                            "version": "1.4.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "duplexify": "3.5.4",
+                                                "inherits": "2.0.3",
+                                                "pump": "2.0.1"
+                                            },
+                                            "dependencies": {
+                                                "pump": {
+                                                    "version": "2.0.1",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "end-of-stream": "1.4.1",
+                                                        "once": "1.4.0"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "stream-each": {
+                                            "version": "1.2.2",
+                                            "bundled": true,
+                                            "requires": {
+                                                "end-of-stream": "1.4.1",
+                                                "stream-shift": "1.0.0"
+                                            },
+                                            "dependencies": {
+                                                "stream-shift": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        },
+                                        "through2": {
+                                            "version": "2.0.3",
+                                            "bundled": true,
+                                            "requires": {
+                                                "readable-stream": "2.3.5",
+                                                "xtend": "4.0.1"
+                                            },
+                                            "dependencies": {
+                                                "xtend": {
+                                                    "version": "4.0.1",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "node-fetch-npm": {
+                                    "version": "2.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "encoding": "0.1.12",
+                                        "json-parse-better-errors": "1.0.1",
+                                        "safe-buffer": "5.1.1"
+                                    },
+                                    "dependencies": {
+                                        "encoding": {
+                                            "version": "0.1.12",
+                                            "bundled": true,
+                                            "requires": {
+                                                "iconv-lite": "0.4.19"
+                                            },
+                                            "dependencies": {
+                                                "iconv-lite": {
+                                                    "version": "0.4.19",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        },
+                                        "json-parse-better-errors": {
+                                            "version": "1.0.1",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "socks-proxy-agent": {
+                                    "version": "3.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "agent-base": "4.2.0",
+                                        "socks": "1.1.10"
+                                    },
+                                    "dependencies": {
+                                        "agent-base": {
+                                            "version": "4.2.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "es6-promisify": "5.0.0"
+                                            },
+                                            "dependencies": {
+                                                "es6-promisify": {
+                                                    "version": "5.0.0",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "es6-promise": "4.2.4"
+                                                    },
+                                                    "dependencies": {
+                                                        "es6-promise": {
+                                                            "version": "4.2.4",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "socks": {
+                                            "version": "1.1.10",
+                                            "bundled": true,
+                                            "requires": {
+                                                "ip": "1.1.5",
+                                                "smart-buffer": "1.1.15"
+                                            },
+                                            "dependencies": {
+                                                "ip": {
+                                                    "version": "1.1.5",
+                                                    "bundled": true
+                                                },
+                                                "smart-buffer": {
+                                                    "version": "1.1.15",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "minimatch": {
+                            "version": "3.0.4",
+                            "bundled": true,
+                            "requires": {
+                                "brace-expansion": "1.1.11"
+                            },
+                            "dependencies": {
+                                "brace-expansion": {
+                                    "version": "1.1.11",
+                                    "bundled": true,
+                                    "requires": {
+                                        "balanced-match": "1.0.0",
+                                        "concat-map": "0.0.1"
+                                    },
+                                    "dependencies": {
+                                        "balanced-match": {
+                                            "version": "1.0.0",
+                                            "bundled": true
+                                        },
+                                        "concat-map": {
+                                            "version": "0.0.1",
+                                            "bundled": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "npm-pick-manifest": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "npm-package-arg": "6.0.0",
+                                "semver": "5.5.0"
+                            }
+                        },
+                        "promise-retry": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "err-code": "1.1.2",
+                                "retry": "0.10.1"
+                            },
+                            "dependencies": {
+                                "err-code": {
+                                    "version": "1.1.2",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "protoduck": {
+                            "version": "5.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "genfun": "4.0.1"
+                            },
+                            "dependencies": {
+                                "genfun": {
+                                    "version": "4.0.1",
+                                    "bundled": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "path-is-inside": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "promise-inflight": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "qrcode-terminal": {
+                    "version": "0.11.0",
+                    "bundled": true
+                },
+                "query-string": {
+                    "version": "5.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "decode-uri-component": "0.2.0",
+                        "object-assign": "4.1.1",
+                        "strict-uri-encode": "1.1.0"
+                    },
+                    "dependencies": {
+                        "decode-uri-component": {
+                            "version": "0.2.0",
+                            "bundled": true
+                        },
+                        "object-assign": {
+                            "version": "4.1.1",
+                            "bundled": true
+                        },
+                        "strict-uri-encode": {
+                            "version": "1.1.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "qw": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "read": {
+                    "version": "1.0.7",
+                    "bundled": true,
+                    "requires": {
+                        "mute-stream": "0.0.7"
+                    },
+                    "dependencies": {
+                        "mute-stream": {
+                            "version": "0.0.7",
+                            "bundled": true
+                        }
+                    }
+                },
+                "read-cmd-shim": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11"
+                    }
+                },
+                "read-installed": {
+                    "version": "4.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "debuglog": "1.0.1",
+                        "graceful-fs": "4.1.11",
+                        "read-package-json": "2.0.13",
+                        "readdir-scoped-modules": "1.0.2",
+                        "semver": "5.5.0",
+                        "slide": "1.1.6",
+                        "util-extend": "1.0.3"
+                    },
+                    "dependencies": {
+                        "util-extend": {
+                            "version": "1.0.3",
+                            "bundled": true
+                        }
+                    }
+                },
+                "read-package-json": {
+                    "version": "2.0.13",
+                    "bundled": true,
+                    "requires": {
+                        "glob": "7.1.2",
+                        "graceful-fs": "4.1.11",
+                        "json-parse-better-errors": "1.0.1",
+                        "normalize-package-data": "2.4.0",
+                        "slash": "1.0.0"
+                    },
+                    "dependencies": {
+                        "json-parse-better-errors": {
+                            "version": "1.0.1",
+                            "bundled": true
+                        },
+                        "slash": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "read-package-tree": {
+                    "version": "5.1.6",
+                    "bundled": true,
+                    "requires": {
+                        "debuglog": "1.0.1",
+                        "dezalgo": "1.0.3",
+                        "once": "1.4.0",
+                        "read-package-json": "2.0.13",
+                        "readdir-scoped-modules": "1.0.2"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "bundled": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    },
+                    "dependencies": {
+                        "core-util-is": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        },
+                        "isarray": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "process-nextick-args": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        },
+                        "string_decoder": {
+                            "version": "1.0.3",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "5.1.1"
+                            }
+                        },
+                        "util-deprecate": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        }
+                    }
+                },
+                "readdir-scoped-modules": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "debuglog": "1.0.1",
+                        "dezalgo": "1.0.3",
+                        "graceful-fs": "4.1.11",
+                        "once": "1.4.0"
+                    }
+                },
+                "request": {
+                    "version": "2.83.0",
+                    "bundled": true,
+                    "requires": {
+                        "aws-sign2": "0.7.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.3.1",
+                        "har-validator": "5.0.3",
+                        "hawk": "6.0.2",
+                        "http-signature": "1.2.0",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.17",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "2.1.0",
+                        "qs": "6.5.1",
+                        "safe-buffer": "5.1.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.3",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.2.1"
+                    },
+                    "dependencies": {
+                        "aws-sign2": {
+                            "version": "0.7.0",
+                            "bundled": true
+                        },
+                        "aws4": {
+                            "version": "1.6.0",
+                            "bundled": true
+                        },
+                        "caseless": {
+                            "version": "0.12.0",
+                            "bundled": true
+                        },
+                        "combined-stream": {
+                            "version": "1.0.5",
+                            "bundled": true,
+                            "requires": {
+                                "delayed-stream": "1.0.0"
+                            },
+                            "dependencies": {
+                                "delayed-stream": {
+                                    "version": "1.0.0",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "extend": {
+                            "version": "3.0.1",
+                            "bundled": true
+                        },
+                        "forever-agent": {
+                            "version": "0.6.1",
+                            "bundled": true
+                        },
+                        "form-data": {
+                            "version": "2.3.1",
+                            "bundled": true,
+                            "requires": {
+                                "asynckit": "0.4.0",
+                                "combined-stream": "1.0.5",
+                                "mime-types": "2.1.17"
+                            },
+                            "dependencies": {
+                                "asynckit": {
+                                    "version": "0.4.0",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "har-validator": {
+                            "version": "5.0.3",
+                            "bundled": true,
+                            "requires": {
+                                "ajv": "5.2.3",
+                                "har-schema": "2.0.0"
+                            },
+                            "dependencies": {
+                                "ajv": {
+                                    "version": "5.2.3",
+                                    "bundled": true,
+                                    "requires": {
+                                        "co": "4.6.0",
+                                        "fast-deep-equal": "1.0.0",
+                                        "json-schema-traverse": "0.3.1",
+                                        "json-stable-stringify": "1.0.1"
+                                    },
+                                    "dependencies": {
+                                        "co": {
+                                            "version": "4.6.0",
+                                            "bundled": true
+                                        },
+                                        "fast-deep-equal": {
+                                            "version": "1.0.0",
+                                            "bundled": true
+                                        },
+                                        "json-schema-traverse": {
+                                            "version": "0.3.1",
+                                            "bundled": true
+                                        },
+                                        "json-stable-stringify": {
+                                            "version": "1.0.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "jsonify": "0.0.0"
+                                            },
+                                            "dependencies": {
+                                                "jsonify": {
+                                                    "version": "0.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "har-schema": {
+                                    "version": "2.0.0",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "hawk": {
+                            "version": "6.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "boom": "4.3.1",
+                                "cryptiles": "3.1.2",
+                                "hoek": "4.2.0",
+                                "sntp": "2.0.2"
+                            },
+                            "dependencies": {
+                                "boom": {
+                                    "version": "4.3.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "hoek": "4.2.0"
+                                    }
+                                },
+                                "cryptiles": {
+                                    "version": "3.1.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "boom": "5.2.0"
+                                    },
+                                    "dependencies": {
+                                        "boom": {
+                                            "version": "5.2.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "hoek": "4.2.0"
+                                            }
+                                        }
+                                    }
+                                },
+                                "hoek": {
+                                    "version": "4.2.0",
+                                    "bundled": true
+                                },
+                                "sntp": {
+                                    "version": "2.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "hoek": "4.2.0"
+                                    }
+                                }
+                            }
+                        },
+                        "http-signature": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "requires": {
+                                "assert-plus": "1.0.0",
+                                "jsprim": "1.4.1",
+                                "sshpk": "1.13.1"
+                            },
+                            "dependencies": {
+                                "assert-plus": {
+                                    "version": "1.0.0",
+                                    "bundled": true
+                                },
+                                "jsprim": {
+                                    "version": "1.4.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "assert-plus": "1.0.0",
+                                        "extsprintf": "1.3.0",
+                                        "json-schema": "0.2.3",
+                                        "verror": "1.10.0"
+                                    },
+                                    "dependencies": {
+                                        "extsprintf": {
+                                            "version": "1.3.0",
+                                            "bundled": true
+                                        },
+                                        "json-schema": {
+                                            "version": "0.2.3",
+                                            "bundled": true
+                                        },
+                                        "verror": {
+                                            "version": "1.10.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "assert-plus": "1.0.0",
+                                                "core-util-is": "1.0.2",
+                                                "extsprintf": "1.3.0"
+                                            },
+                                            "dependencies": {
+                                                "core-util-is": {
+                                                    "version": "1.0.2",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "sshpk": {
+                                    "version": "1.13.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "asn1": "0.2.3",
+                                        "assert-plus": "1.0.0",
+                                        "bcrypt-pbkdf": "1.0.1",
+                                        "dashdash": "1.14.1",
+                                        "ecc-jsbn": "0.1.1",
+                                        "getpass": "0.1.7",
+                                        "jsbn": "0.1.1",
+                                        "tweetnacl": "0.14.5"
+                                    },
+                                    "dependencies": {
+                                        "asn1": {
+                                            "version": "0.2.3",
+                                            "bundled": true
+                                        },
+                                        "bcrypt-pbkdf": {
+                                            "version": "1.0.1",
+                                            "bundled": true,
+                                            "optional": true,
+                                            "requires": {
+                                                "tweetnacl": "0.14.5"
+                                            }
+                                        },
+                                        "dashdash": {
+                                            "version": "1.14.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "assert-plus": "1.0.0"
+                                            }
+                                        },
+                                        "ecc-jsbn": {
+                                            "version": "0.1.1",
+                                            "bundled": true,
+                                            "optional": true,
+                                            "requires": {
+                                                "jsbn": "0.1.1"
+                                            }
+                                        },
+                                        "getpass": {
+                                            "version": "0.1.7",
+                                            "bundled": true,
+                                            "requires": {
+                                                "assert-plus": "1.0.0"
+                                            }
+                                        },
+                                        "jsbn": {
+                                            "version": "0.1.1",
+                                            "bundled": true,
+                                            "optional": true
+                                        },
+                                        "tweetnacl": {
+                                            "version": "0.14.5",
+                                            "bundled": true,
+                                            "optional": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "is-typedarray": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "isstream": {
+                            "version": "0.1.2",
+                            "bundled": true
+                        },
+                        "json-stringify-safe": {
+                            "version": "5.0.1",
+                            "bundled": true
+                        },
+                        "mime-types": {
+                            "version": "2.1.17",
+                            "bundled": true,
+                            "requires": {
+                                "mime-db": "1.30.0"
+                            },
+                            "dependencies": {
+                                "mime-db": {
+                                    "version": "1.30.0",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "oauth-sign": {
+                            "version": "0.8.2",
+                            "bundled": true
+                        },
+                        "performance-now": {
+                            "version": "2.1.0",
+                            "bundled": true
+                        },
+                        "qs": {
+                            "version": "6.5.1",
+                            "bundled": true
+                        },
+                        "stringstream": {
+                            "version": "0.0.5",
+                            "bundled": true
+                        },
+                        "tough-cookie": {
+                            "version": "2.3.3",
+                            "bundled": true,
+                            "requires": {
+                                "punycode": "1.4.1"
+                            },
+                            "dependencies": {
+                                "punycode": {
+                                    "version": "1.4.1",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "tunnel-agent": {
+                            "version": "0.6.0",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "5.1.1"
+                            }
+                        }
+                    }
+                },
+                "retry": {
+                    "version": "0.10.1",
+                    "bundled": true
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "bundled": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "bundled": true
+                },
+                "semver": {
+                    "version": "5.5.0",
+                    "bundled": true
+                },
+                "sha": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "readable-stream": "2.3.5"
+                    }
+                },
+                "slide": {
+                    "version": "1.1.6",
+                    "bundled": true
+                },
+                "sorted-object": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
+                "sorted-union-stream": {
+                    "version": "2.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "from2": "1.3.0",
+                        "stream-iterate": "1.2.0"
+                    },
+                    "dependencies": {
+                        "from2": {
+                            "version": "1.3.0",
+                            "bundled": true,
+                            "requires": {
+                                "inherits": "2.0.3",
+                                "readable-stream": "1.1.14"
+                            },
+                            "dependencies": {
+                                "readable-stream": {
+                                    "version": "1.1.14",
+                                    "bundled": true,
+                                    "requires": {
+                                        "core-util-is": "1.0.2",
+                                        "inherits": "2.0.3",
+                                        "isarray": "0.0.1",
+                                        "string_decoder": "0.10.31"
+                                    },
+                                    "dependencies": {
+                                        "core-util-is": {
+                                            "version": "1.0.2",
+                                            "bundled": true
+                                        },
+                                        "isarray": {
+                                            "version": "0.0.1",
+                                            "bundled": true
+                                        },
+                                        "string_decoder": {
+                                            "version": "0.10.31",
+                                            "bundled": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "stream-iterate": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "requires": {
+                                "readable-stream": "2.3.5",
+                                "stream-shift": "1.0.0"
+                            },
+                            "dependencies": {
+                                "stream-shift": {
+                                    "version": "1.0.0",
+                                    "bundled": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "ssri": {
+                    "version": "5.2.4",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "tar": {
+                    "version": "4.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "chownr": "1.0.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.2.1",
+                        "minizlib": "1.1.0",
+                        "mkdirp": "0.5.1",
+                        "yallist": "3.0.2"
+                    },
+                    "dependencies": {
+                        "fs-minipass": {
+                            "version": "1.2.5",
+                            "bundled": true,
+                            "requires": {
+                                "minipass": "2.2.1"
+                            }
+                        },
+                        "minipass": {
+                            "version": "2.2.1",
+                            "bundled": true,
+                            "requires": {
+                                "yallist": "3.0.2"
+                            }
+                        },
+                        "minizlib": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "minipass": "2.2.1"
+                            }
+                        },
+                        "yallist": {
+                            "version": "3.0.2",
+                            "bundled": true
+                        }
+                    }
+                },
+                "text-table": {
+                    "version": "0.2.0",
+                    "bundled": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true
+                },
+                "umask": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "unique-filename": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "unique-slug": "2.0.0"
+                    },
+                    "dependencies": {
+                        "unique-slug": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "imurmurhash": "0.1.4"
+                            }
+                        }
+                    }
+                },
+                "unpipe": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "update-notifier": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "boxen": "1.2.1",
+                        "chalk": "2.1.0",
+                        "configstore": "3.1.1",
+                        "import-lazy": "2.1.0",
+                        "is-installed-globally": "0.1.0",
+                        "is-npm": "1.0.0",
+                        "latest-version": "3.1.0",
+                        "semver-diff": "2.1.0",
+                        "xdg-basedir": "3.0.0"
+                    },
+                    "dependencies": {
+                        "boxen": {
+                            "version": "1.2.1",
+                            "bundled": true,
+                            "requires": {
+                                "ansi-align": "2.0.0",
+                                "camelcase": "4.1.0",
+                                "chalk": "2.1.0",
+                                "cli-boxes": "1.0.0",
+                                "string-width": "2.1.1",
+                                "term-size": "1.2.0",
+                                "widest-line": "1.0.0"
+                            },
+                            "dependencies": {
+                                "ansi-align": {
+                                    "version": "2.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "string-width": "2.1.1"
+                                    }
+                                },
+                                "camelcase": {
+                                    "version": "4.1.0",
+                                    "bundled": true
+                                },
+                                "cli-boxes": {
+                                    "version": "1.0.0",
+                                    "bundled": true
+                                },
+                                "string-width": {
+                                    "version": "2.1.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-fullwidth-code-point": "2.0.0",
+                                        "strip-ansi": "4.0.0"
+                                    },
+                                    "dependencies": {
+                                        "is-fullwidth-code-point": {
+                                            "version": "2.0.0",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "term-size": {
+                                    "version": "1.2.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "execa": "0.7.0"
+                                    },
+                                    "dependencies": {
+                                        "execa": {
+                                            "version": "0.7.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "cross-spawn": "5.1.0",
+                                                "get-stream": "3.0.0",
+                                                "is-stream": "1.1.0",
+                                                "npm-run-path": "2.0.2",
+                                                "p-finally": "1.0.0",
+                                                "signal-exit": "3.0.2",
+                                                "strip-eof": "1.0.0"
+                                            },
+                                            "dependencies": {
+                                                "cross-spawn": {
+                                                    "version": "5.1.0",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "lru-cache": "4.1.1",
+                                                        "shebang-command": "1.2.0",
+                                                        "which": "1.3.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "shebang-command": {
+                                                            "version": "1.2.0",
+                                                            "bundled": true,
+                                                            "requires": {
+                                                                "shebang-regex": "1.0.0"
+                                                            },
+                                                            "dependencies": {
+                                                                "shebang-regex": {
+                                                                    "version": "1.0.0",
+                                                                    "bundled": true
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "get-stream": {
+                                                    "version": "3.0.0",
+                                                    "bundled": true
+                                                },
+                                                "is-stream": {
+                                                    "version": "1.1.0",
+                                                    "bundled": true
+                                                },
+                                                "npm-run-path": {
+                                                    "version": "2.0.2",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "path-key": "2.0.1"
+                                                    },
+                                                    "dependencies": {
+                                                        "path-key": {
+                                                            "version": "2.0.1",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                },
+                                                "p-finally": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                },
+                                                "signal-exit": {
+                                                    "version": "3.0.2",
+                                                    "bundled": true
+                                                },
+                                                "strip-eof": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "widest-line": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "string-width": "1.0.2"
+                                    },
+                                    "dependencies": {
+                                        "string-width": {
+                                            "version": "1.0.2",
+                                            "bundled": true,
+                                            "requires": {
+                                                "code-point-at": "1.1.0",
+                                                "is-fullwidth-code-point": "1.0.0",
+                                                "strip-ansi": "3.0.1"
+                                            },
+                                            "dependencies": {
+                                                "code-point-at": {
+                                                    "version": "1.1.0",
+                                                    "bundled": true
+                                                },
+                                                "is-fullwidth-code-point": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "number-is-nan": "1.0.1"
+                                                    },
+                                                    "dependencies": {
+                                                        "number-is-nan": {
+                                                            "version": "1.0.1",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                },
+                                                "strip-ansi": {
+                                                    "version": "3.0.1",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "ansi-regex": "2.1.1"
+                                                    },
+                                                    "dependencies": {
+                                                        "ansi-regex": {
+                                                            "version": "2.1.1",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "chalk": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "ansi-styles": "3.2.0",
+                                "escape-string-regexp": "1.0.5",
+                                "supports-color": "4.4.0"
+                            },
+                            "dependencies": {
+                                "ansi-styles": {
+                                    "version": "3.2.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "color-convert": "1.9.0"
+                                    },
+                                    "dependencies": {
+                                        "color-convert": {
+                                            "version": "1.9.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "color-name": "1.1.3"
+                                            },
+                                            "dependencies": {
+                                                "color-name": {
+                                                    "version": "1.1.3",
+                                                    "bundled": true
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "escape-string-regexp": {
+                                    "version": "1.0.5",
+                                    "bundled": true
+                                },
+                                "supports-color": {
+                                    "version": "4.4.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "has-flag": "2.0.0"
+                                    },
+                                    "dependencies": {
+                                        "has-flag": {
+                                            "version": "2.0.0",
+                                            "bundled": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "configstore": {
+                            "version": "3.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "dot-prop": "4.2.0",
+                                "graceful-fs": "4.1.11",
+                                "make-dir": "1.0.0",
+                                "unique-string": "1.0.0",
+                                "write-file-atomic": "2.3.0",
+                                "xdg-basedir": "3.0.0"
+                            },
+                            "dependencies": {
+                                "dot-prop": {
+                                    "version": "4.2.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-obj": "1.0.1"
+                                    },
+                                    "dependencies": {
+                                        "is-obj": {
+                                            "version": "1.0.1",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "make-dir": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "pify": "2.3.0"
+                                    },
+                                    "dependencies": {
+                                        "pify": {
+                                            "version": "2.3.0",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "unique-string": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "crypto-random-string": "1.0.0"
+                                    },
+                                    "dependencies": {
+                                        "crypto-random-string": {
+                                            "version": "1.0.0",
+                                            "bundled": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "import-lazy": {
+                            "version": "2.1.0",
+                            "bundled": true
+                        },
+                        "is-installed-globally": {
+                            "version": "0.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "global-dirs": "0.1.0",
+                                "is-path-inside": "1.0.0"
+                            },
+                            "dependencies": {
+                                "global-dirs": {
+                                    "version": "0.1.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "ini": "1.3.5"
+                                    }
+                                },
+                                "is-path-inside": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "path-is-inside": "1.0.2"
+                                    }
+                                }
+                            }
+                        },
+                        "is-npm": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "latest-version": {
+                            "version": "3.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "package-json": "4.0.1"
+                            },
+                            "dependencies": {
+                                "package-json": {
+                                    "version": "4.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "got": "6.7.1",
+                                        "registry-auth-token": "3.3.1",
+                                        "registry-url": "3.1.0",
+                                        "semver": "5.5.0"
+                                    },
+                                    "dependencies": {
+                                        "got": {
+                                            "version": "6.7.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "create-error-class": "3.0.2",
+                                                "duplexer3": "0.1.4",
+                                                "get-stream": "3.0.0",
+                                                "is-redirect": "1.0.0",
+                                                "is-retry-allowed": "1.1.0",
+                                                "is-stream": "1.1.0",
+                                                "lowercase-keys": "1.0.0",
+                                                "safe-buffer": "5.1.1",
+                                                "timed-out": "4.0.1",
+                                                "unzip-response": "2.0.1",
+                                                "url-parse-lax": "1.0.0"
+                                            },
+                                            "dependencies": {
+                                                "create-error-class": {
+                                                    "version": "3.0.2",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "capture-stack-trace": "1.0.0"
+                                                    },
+                                                    "dependencies": {
+                                                        "capture-stack-trace": {
+                                                            "version": "1.0.0",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                },
+                                                "duplexer3": {
+                                                    "version": "0.1.4",
+                                                    "bundled": true
+                                                },
+                                                "get-stream": {
+                                                    "version": "3.0.0",
+                                                    "bundled": true
+                                                },
+                                                "is-redirect": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                },
+                                                "is-retry-allowed": {
+                                                    "version": "1.1.0",
+                                                    "bundled": true
+                                                },
+                                                "is-stream": {
+                                                    "version": "1.1.0",
+                                                    "bundled": true
+                                                },
+                                                "lowercase-keys": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true
+                                                },
+                                                "timed-out": {
+                                                    "version": "4.0.1",
+                                                    "bundled": true
+                                                },
+                                                "unzip-response": {
+                                                    "version": "2.0.1",
+                                                    "bundled": true
+                                                },
+                                                "url-parse-lax": {
+                                                    "version": "1.0.0",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "prepend-http": "1.0.4"
+                                                    },
+                                                    "dependencies": {
+                                                        "prepend-http": {
+                                                            "version": "1.0.4",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "registry-auth-token": {
+                                            "version": "3.3.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "rc": "1.2.1",
+                                                "safe-buffer": "5.1.1"
+                                            },
+                                            "dependencies": {
+                                                "rc": {
+                                                    "version": "1.2.1",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "deep-extend": "0.4.2",
+                                                        "ini": "1.3.5",
+                                                        "minimist": "1.2.0",
+                                                        "strip-json-comments": "2.0.1"
+                                                    },
+                                                    "dependencies": {
+                                                        "deep-extend": {
+                                                            "version": "0.4.2",
+                                                            "bundled": true
+                                                        },
+                                                        "minimist": {
+                                                            "version": "1.2.0",
+                                                            "bundled": true
+                                                        },
+                                                        "strip-json-comments": {
+                                                            "version": "2.0.1",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "registry-url": {
+                                            "version": "3.1.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "rc": "1.2.1"
+                                            },
+                                            "dependencies": {
+                                                "rc": {
+                                                    "version": "1.2.1",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "deep-extend": "0.4.2",
+                                                        "ini": "1.3.5",
+                                                        "minimist": "1.2.0",
+                                                        "strip-json-comments": "2.0.1"
+                                                    },
+                                                    "dependencies": {
+                                                        "deep-extend": {
+                                                            "version": "0.4.2",
+                                                            "bundled": true
+                                                        },
+                                                        "minimist": {
+                                                            "version": "1.2.0",
+                                                            "bundled": true
+                                                        },
+                                                        "strip-json-comments": {
+                                                            "version": "2.0.1",
+                                                            "bundled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "semver-diff": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "semver": "5.5.0"
+                            }
+                        },
+                        "xdg-basedir": {
+                            "version": "3.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "uuid": {
+                    "version": "3.2.1",
+                    "bundled": true
+                },
+                "validate-npm-package-license": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "spdx-correct": "1.0.2",
+                        "spdx-expression-parse": "1.0.4"
+                    },
+                    "dependencies": {
+                        "spdx-correct": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "spdx-license-ids": "1.2.2"
+                            },
+                            "dependencies": {
+                                "spdx-license-ids": {
+                                    "version": "1.2.2",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "spdx-expression-parse": {
+                            "version": "1.0.4",
+                            "bundled": true
+                        }
+                    }
+                },
+                "validate-npm-package-name": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "builtins": "1.0.3"
+                    },
+                    "dependencies": {
+                        "builtins": {
+                            "version": "1.0.3",
+                            "bundled": true
+                        }
+                    }
+                },
+                "which": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "isexe": "2.0.0"
+                    },
+                    "dependencies": {
+                        "isexe": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "worker-farm": {
+                    "version": "1.5.4",
+                    "bundled": true,
+                    "requires": {
+                        "errno": "0.1.7",
+                        "xtend": "4.0.1"
+                    },
+                    "dependencies": {
+                        "errno": {
+                            "version": "0.1.7",
+                            "bundled": true,
+                            "requires": {
+                                "prr": "1.0.1"
+                            },
+                            "dependencies": {
+                                "prr": {
+                                    "version": "1.0.1",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "xtend": {
+                            "version": "4.0.1",
+                            "bundled": true
+                        }
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "write-file-atomic": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "imurmurhash": "0.1.4",
+                        "signal-exit": "3.0.2"
+                    },
+                    "dependencies": {
+                        "signal-exit": {
+                            "version": "3.0.2",
+                            "bundled": true
+                        }
+                    }
+                }
             }
         },
         "npm-check": {
@@ -8286,6 +12375,11 @@
             "resolved": "http://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
+        "object-hash": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.0.tgz",
+            "integrity": "sha512-05KzQ70lSeGSrZJQXE5wNDiTkBJDlUT/myi6RX9dVIvz7a7Qh4oH93BQdiPMn27nldYvVQCKMUaM83AfizZlsQ=="
+        },
         "object-keys": {
             "version": "0.4.0",
             "resolved": "http://registry.npm.taobao.org/object-keys/download/object-keys-0.4.0.tgz",
@@ -8454,6 +12548,11 @@
             "version": "0.1.0",
             "resolved": "http://registry.npm.taobao.org/ordered-read-streams/download/ordered-read-streams-0.1.0.tgz",
             "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY="
+        },
+        "os": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+            "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
         },
         "os-browserify": {
             "version": "0.2.1",
@@ -8650,14 +12749,6 @@
                 }
             }
         },
-        "pause-stream": {
-            "version": "0.0.11",
-            "resolved": "http://registry.npm.taobao.org/pause-stream/download/pause-stream-0.0.11.tgz",
-            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-            "requires": {
-                "through": "2.3.8"
-            }
-        },
         "pbkdf2": {
             "version": "3.0.14",
             "resolved": "http://registry.npm.taobao.org/pbkdf2/download/pbkdf2-3.0.14.tgz",
@@ -8711,6 +12802,11 @@
             "version": "0.4.1",
             "resolved": "http://registry.npm.taobao.org/pkginfo/download/pkginfo-0.4.1.tgz",
             "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
+        },
+        "pluralize": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
         },
         "postcss": {
             "version": "5.2.18",
@@ -8863,6 +12959,90 @@
             "requires": {
                 "cosmiconfig": "2.2.2",
                 "object-assign": "4.1.1"
+            }
+        },
+        "postcss-loader": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.4.tgz",
+            "integrity": "sha512-L2p654oK945B/gDFUGgOhh7uzj19RWoY1SVMeJVoKno1H2MdbQ0RppR/28JGju4pMb22iRC7BJ9aDzbxXSLf4A==",
+            "requires": {
+                "loader-utils": "1.1.0",
+                "postcss": "6.0.21",
+                "postcss-load-config": "1.2.0",
+                "schema-utils": "0.4.5"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.4.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+                    "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+                    "requires": {
+                        "fast-deep-equal": "1.0.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1",
+                        "uri-js": "3.0.2"
+                    }
+                },
+                "ajv-keywords": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+                    "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74="
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "1.9.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                    "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                    "requires": {
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+                },
+                "postcss": {
+                    "version": "6.0.21",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+                    "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+                    "requires": {
+                        "chalk": "2.4.0",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "schema-utils": {
+                    "version": "0.4.5",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+                    "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+                    "requires": {
+                        "ajv": "6.4.0",
+                        "ajv-keywords": "3.1.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
             }
         },
         "postcss-merge-idents": {
@@ -9115,6 +13295,28 @@
                 "postcss-value-parser": "3.3.0"
             }
         },
+        "postcss-plugin-px2rem": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/postcss-plugin-px2rem/-/postcss-plugin-px2rem-0.7.0.tgz",
+            "integrity": "sha1-UXjPZNLcYumNSNHM/QU+5KAOJUU=",
+            "requires": {
+                "postcss": "5.2.18"
+            }
+        },
+        "postcss-plugin-weex": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/postcss-plugin-weex/-/postcss-plugin-weex-0.1.6.tgz",
+            "integrity": "sha512-B92g02Va+SPzP6AIlfhTMD6WBPrRL77ESKR36N27uhJP2OA4Lkni9YYsMEeHRB607FGkqYKQJ1edbdY9zw2+LA=="
+        },
+        "postcss-px2rem": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-px2rem/-/postcss-px2rem-0.3.0.tgz",
+            "integrity": "sha1-DfpOiiaPp0eCc/DEtHxhmDSJQEE=",
+            "requires": {
+                "postcss": "5.2.18",
+                "px2rem": "0.5.0"
+            }
+        },
         "postcss-reduce-idents": {
             "version": "2.4.0",
             "resolved": "http://registry.npm.taobao.org/postcss-reduce-idents/download/postcss-reduce-idents-2.4.0.tgz",
@@ -9203,11 +13405,6 @@
             "resolved": "http://registry.npm.taobao.org/preserve/download/preserve-0.2.0.tgz",
             "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
         },
-        "prettier": {
-            "version": "1.8.2",
-            "resolved": "http://registry.npm.taobao.org/prettier/download/prettier-1.8.2.tgz",
-            "integrity": "sha1-v/g+f9VzkzxgeHXlujq73/uWrrg="
-        },
         "pretty-hrtime": {
             "version": "1.0.2",
             "resolved": "http://registry.npm.taobao.org/pretty-hrtime/download/pretty-hrtime-1.0.2.tgz",
@@ -9233,11 +13430,15 @@
             "resolved": "http://registry.npm.taobao.org/process-nextick-args/download/process-nextick-args-1.0.7.tgz",
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
+        "progress": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+        },
         "promise": {
             "version": "7.3.1",
             "resolved": "http://registry.npm.taobao.org/promise/download/promise-7.3.1.tgz",
             "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
-            "optional": true,
             "requires": {
                 "asap": "2.0.6"
             }
@@ -9291,6 +13492,86 @@
             "version": "1.4.1",
             "resolved": "http://registry.npm.taobao.org/punycode/download/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "px2rem": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/px2rem/-/px2rem-0.5.0.tgz",
+            "integrity": "sha1-JLOmz3TRSttO13byB4cdmJPkEOI=",
+            "requires": {
+                "chalk": "0.5.1",
+                "commander": "2.6.0",
+                "css": "2.2.1",
+                "extend": "3.0.1",
+                "fs-extra": "0.16.5"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                    "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
+                },
+                "ansi-styles": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                    "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
+                },
+                "chalk": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                    "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+                    "requires": {
+                        "ansi-styles": "1.1.0",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "0.1.0",
+                        "strip-ansi": "0.3.0",
+                        "supports-color": "0.2.0"
+                    }
+                },
+                "commander": {
+                    "version": "2.6.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+                    "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0="
+                },
+                "fs-extra": {
+                    "version": "0.16.5",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
+                    "integrity": "sha1-GtZh+myGyWCM0bSe/G/Og0k5p1A=",
+                    "requires": {
+                        "graceful-fs": "3.0.11",
+                        "jsonfile": "2.4.0",
+                        "rimraf": "2.6.2"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "3.0.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+                    "requires": {
+                        "natives": "1.1.0"
+                    }
+                },
+                "has-ansi": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                    "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+                    "requires": {
+                        "ansi-regex": "0.2.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                    "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+                    "requires": {
+                        "ansi-regex": "0.2.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                    "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+                }
+            }
         },
         "q": {
             "version": "1.5.1",
@@ -9525,6 +13806,30 @@
                 "resolve": "1.5.0"
             }
         },
+        "recursive-copy": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/recursive-copy/-/recursive-copy-2.0.9.tgz",
+            "integrity": "sha512-0AkHV+QtfS/1jW01z3m2t/TRTW56Fpc+xYbsoa/bqn8BCYPwmsaNjlYmUU/dyGg9w8MmGoUWihU5W+s+qjxvBQ==",
+            "requires": {
+                "del": "2.2.2",
+                "emitter-mixin": "0.0.3",
+                "errno": "0.1.4",
+                "graceful-fs": "4.1.11",
+                "junk": "1.0.3",
+                "maximatch": "0.1.0",
+                "mkdirp": "0.5.1",
+                "pify": "2.3.0",
+                "promise": "7.3.1",
+                "slash": "1.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                }
+            }
+        },
         "redent": {
             "version": "1.0.0",
             "resolved": "http://registry.npm.taobao.org/redent/download/redent-1.0.0.tgz",
@@ -9593,6 +13898,11 @@
             "requires": {
                 "is-equal-shallow": "0.1.3"
             }
+        },
+        "regexpp": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+            "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw=="
         },
         "regexpu-core": {
             "version": "2.0.0",
@@ -9835,6 +14145,15 @@
             "resolved": "http://registry.npm.taobao.org/require-package-name/download/require-package-name-2.0.1.tgz",
             "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk="
         },
+        "require-uncached": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+            "requires": {
+                "caller-path": "0.1.0",
+                "resolve-from": "1.0.1"
+            }
+        },
         "resolve": {
             "version": "1.5.0",
             "resolved": "http://registry.npm.taobao.org/resolve/download/resolve-1.5.0.tgz",
@@ -9859,6 +14178,11 @@
                 "expand-tilde": "1.2.2",
                 "global-modules": "0.2.3"
             }
+        },
+        "resolve-from": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
         },
         "resolve-url": {
             "version": "0.2.1",
@@ -10126,6 +14450,11 @@
             "resolved": "http://registry.npm.taobao.org/sequencify/download/sequencify-0.0.7.tgz",
             "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw="
         },
+        "serialize-error": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+            "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
+        },
         "serve-index": {
             "version": "1.8.0",
             "resolved": "http://registry.npm.taobao.org/serve-index/download/serve-index-1.8.0.tgz",
@@ -10304,6 +14633,21 @@
             "resolved": "http://registry.npm.taobao.org/slash/download/slash-1.0.0.tgz",
             "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
         },
+        "slice-ansi": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+            "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+            "requires": {
+                "is-fullwidth-code-point": "2.0.0"
+            },
+            "dependencies": {
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                }
+            }
+        },
         "sntp": {
             "version": "1.0.9",
             "resolved": "http://registry.npm.taobao.org/sntp/download/sntp-1.0.9.tgz",
@@ -10378,14 +14722,6 @@
             "resolved": "http://registry.npm.taobao.org/spdx-license-ids/download/spdx-license-ids-1.2.2.tgz",
             "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
         },
-        "split": {
-            "version": "0.3.3",
-            "resolved": "http://registry.npm.taobao.org/split/download/split-0.3.3.tgz",
-            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-            "requires": {
-                "through": "2.3.8"
-            }
-        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "http://registry.npm.taobao.org/sprintf-js/download/sprintf-js-1.0.3.tgz",
@@ -10443,14 +14779,6 @@
             "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.3"
-            }
-        },
-        "stream-combiner": {
-            "version": "0.0.4",
-            "resolved": "http://registry.npm.taobao.org/stream-combiner/download/stream-combiner-0.0.4.tgz",
-            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-            "requires": {
-                "duplexer": "0.1.1"
             }
         },
         "stream-combiner2": {
@@ -10676,6 +15004,64 @@
                     "version": "4.0.13",
                     "resolved": "http://registry.npm.taobao.org/acorn/download/acorn-4.0.13.tgz",
                     "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+                }
+            }
+        },
+        "table": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+            "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+            "requires": {
+                "ajv": "5.5.2",
+                "ajv-keywords": "2.1.1",
+                "chalk": "2.3.0",
+                "lodash": "4.17.5",
+                "slice-ansi": "1.0.0",
+                "string-width": "2.1.1"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "requires": {
+                        "co": "4.6.0",
+                        "fast-deep-equal": "1.0.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                },
+                "lodash": {
+                    "version": "4.17.5",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+                    "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
                 }
             }
         },
@@ -11041,20 +15427,11 @@
                 }
             }
         },
-        "uglify-save-license": {
-            "version": "0.4.1",
-            "resolved": "http://registry.npm.taobao.org/uglify-save-license/download/uglify-save-license-0.4.1.tgz",
-            "integrity": "sha1-lXJsF8xv0XHDYX479NjYKqjEzOE="
-        },
         "uglify-to-browserify": {
             "version": "1.0.2",
             "resolved": "http://registry.npm.taobao.org/uglify-to-browserify/download/uglify-to-browserify-1.0.2.tgz",
-            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
-        },
-        "uglifycss": {
-            "version": "0.0.27",
-            "resolved": "http://registry.npm.taobao.org/uglifycss/download/uglifycss-0.0.27.tgz",
-            "integrity": "sha1-U1U7gRXeJtzle0K6CzTojdgNDN4="
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "optional": true
         },
         "uglifyjs-webpack-plugin": {
             "version": "0.4.6",
@@ -11140,6 +15517,21 @@
                 "latest-version": "3.1.0",
                 "semver-diff": "2.1.0",
                 "xdg-basedir": "3.0.0"
+            }
+        },
+        "uri-js": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+            "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+            "requires": {
+                "punycode": "2.1.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+                    "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+                }
             }
         },
         "urix": {
@@ -11374,64 +15766,38 @@
                 "indexof": "0.0.1"
             }
         },
+        "vue-eslint-parser": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
+            "integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
+            "requires": {
+                "debug": "3.1.0",
+                "eslint-scope": "3.7.1",
+                "eslint-visitor-keys": "1.0.0",
+                "espree": "3.5.4",
+                "esquery": "1.0.1",
+                "lodash": "4.17.5"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.5",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+                    "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+                }
+            }
+        },
         "vue-hot-reload-api": {
             "version": "2.2.3",
             "resolved": "http://registry.npm.taobao.org/vue-hot-reload-api/download/vue-hot-reload-api-2.2.3.tgz",
             "integrity": "sha1-Q8jlUG1lonHSVxk213JTAZ/T6xc="
-        },
-        "vue-loader": {
-            "version": "13.5.0",
-            "resolved": "http://registry.npm.taobao.org/vue-loader/download/vue-loader-13.5.0.tgz",
-            "integrity": "sha1-UvezeQomfv+AASt36hh6VFht1dQ=",
-            "requires": {
-                "consolidate": "0.14.5",
-                "hash-sum": "1.0.2",
-                "loader-utils": "1.1.0",
-                "lru-cache": "4.1.1",
-                "postcss": "6.0.14",
-                "postcss-load-config": "1.2.0",
-                "postcss-selector-parser": "2.2.3",
-                "prettier": "1.8.2",
-                "resolve": "1.5.0",
-                "source-map": "0.6.1",
-                "vue-hot-reload-api": "2.2.3",
-                "vue-style-loader": "3.0.3",
-                "vue-template-es2015-compiler": "1.6.0"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "4.1.1",
-                    "resolved": "http://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.1.tgz",
-                    "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
-                    "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
-                    }
-                },
-                "postcss": {
-                    "version": "6.0.14",
-                    "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-6.0.14.tgz",
-                    "integrity": "sha1-VTTHIRRznnXQr88BfbhTCZ9WKIU=",
-                    "requires": {
-                        "chalk": "2.3.0",
-                        "source-map": "0.6.1",
-                        "supports-color": "4.5.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
-                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
-                },
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
-                }
-            }
         },
         "vue-style-loader": {
             "version": "3.0.3",
@@ -11440,15 +15806,6 @@
             "requires": {
                 "hash-sum": "1.0.2",
                 "loader-utils": "1.1.0"
-            }
-        },
-        "vue-template-compiler": {
-            "version": "2.5.3",
-            "resolved": "http://registry.npm.taobao.org/vue-template-compiler/download/vue-template-compiler-2.5.3.tgz",
-            "integrity": "sha1-q2MbBpTiEaaq8NgAECs3g2quNqQ=",
-            "requires": {
-                "de-indent": "1.0.2",
-                "he": "1.1.1"
             }
         },
         "vue-template-es2015-compiler": {
@@ -11755,40 +16112,153 @@
             "integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk="
         },
         "weex-loader": {
-            "version": "0.4.5",
-            "resolved": "http://registry.npm.taobao.org/weex-loader/download/weex-loader-0.4.5.tgz",
-            "integrity": "sha1-M9wt4y5je5U18XdMx5B0s9EuTYo=",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/weex-loader/-/weex-loader-0.7.3.tgz",
+            "integrity": "sha512-Sj3LBmaJtqAviQOSfEeciy0ISaDVgTIl354+RCIFAboTH2ANrwpv/7uu4K7ZhVeclPcfeN+c7dYzpayGADXglw==",
             "requires": {
                 "babel-loader": "6.4.1",
                 "babel-plugin-transform-runtime": "6.23.0",
                 "babel-preset-es2015": "6.24.1",
                 "babel-runtime": "6.26.0",
                 "hash-sum": "1.0.2",
-                "loader-utils": "0.2.17",
+                "loader-utils": "1.1.0",
                 "md5": "2.2.1",
                 "parse5": "2.2.3",
                 "source-map": "0.5.7",
                 "weex-scripter": "0.1.5",
-                "weex-styler": "0.1.10",
+                "weex-styler": "0.3.1",
                 "weex-templater": "0.3.5",
                 "weex-transformer": "0.4.5",
-                "weex-vue-loader": "0.2.12"
+                "weex-vue-loader": "0.6.1"
             },
             "dependencies": {
                 "babel-loader": {
                     "version": "6.4.1",
-                    "resolved": "http://registry.npm.taobao.org/babel-loader/download/babel-loader-6.4.1.tgz",
+                    "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
                     "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
                     "requires": {
                         "find-cache-dir": "0.1.1",
                         "loader-utils": "0.2.17",
                         "mkdirp": "0.5.1",
                         "object-assign": "4.1.1"
+                    },
+                    "dependencies": {
+                        "loader-utils": {
+                            "version": "0.2.17",
+                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+                            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+                            "requires": {
+                                "big.js": "3.2.0",
+                                "emojis-list": "2.1.0",
+                                "json5": "0.5.1",
+                                "object-assign": "4.1.1"
+                            }
+                        }
                     }
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                        }
+                    }
+                },
+                "css-loader": {
+                    "version": "0.23.1",
+                    "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.23.1.tgz",
+                    "integrity": "sha1-n6I/K1wJZSNZEK1ezvO4o2OQ/lA=",
+                    "requires": {
+                        "css-selector-tokenizer": "0.5.4",
+                        "cssnano": "3.10.0",
+                        "loader-utils": "0.2.17",
+                        "lodash.camelcase": "3.0.1",
+                        "object-assign": "4.1.1",
+                        "postcss": "5.2.18",
+                        "postcss-modules-extract-imports": "1.1.0",
+                        "postcss-modules-local-by-default": "1.2.0",
+                        "postcss-modules-scope": "1.1.0",
+                        "postcss-modules-values": "1.3.0",
+                        "source-list-map": "0.1.8"
+                    },
+                    "dependencies": {
+                        "loader-utils": {
+                            "version": "0.2.17",
+                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+                            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+                            "requires": {
+                                "big.js": "3.2.0",
+                                "emojis-list": "2.1.0",
+                                "json5": "0.5.1",
+                                "object-assign": "4.1.1"
+                            }
+                        },
+                        "postcss": {
+                            "version": "5.2.18",
+                            "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+                            "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+                            "requires": {
+                                "chalk": "1.1.3",
+                                "js-base64": "2.3.2",
+                                "source-map": "0.5.7",
+                                "supports-color": "3.2.3"
+                            }
+                        }
+                    }
+                },
+                "css-selector-tokenizer": {
+                    "version": "0.5.4",
+                    "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
+                    "integrity": "sha1-E5uv00o1/QwUKEhwSeBpnm9qLCE=",
+                    "requires": {
+                        "cssesc": "0.1.0",
+                        "fastparse": "1.1.1"
+                    }
+                },
+                "escodegen": {
+                    "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+                    "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+                    "requires": {
+                        "esprima": "3.1.3",
+                        "estraverse": "4.2.0",
+                        "esutils": "2.0.2",
+                        "optionator": "0.8.2",
+                        "source-map": "0.6.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                            "optional": true
+                        }
+                    }
+                },
+                "esprima": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+                },
+                "fast-levenshtein": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+                    "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
                 },
                 "find-cache-dir": {
                     "version": "0.1.1",
-                    "resolved": "http://registry.npm.taobao.org/find-cache-dir/download/find-cache-dir-0.1.1.tgz",
+                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
                     "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
                     "requires": {
                         "commondir": "1.0.1",
@@ -11798,36 +16268,60 @@
                 },
                 "find-up": {
                     "version": "1.1.2",
-                    "resolved": "http://registry.npm.taobao.org/find-up/download/find-up-1.1.2.tgz",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "requires": {
                         "path-exists": "2.1.0",
                         "pinkie-promise": "2.0.1"
                     }
                 },
-                "loader-utils": {
-                    "version": "0.2.17",
-                    "resolved": "http://registry.npm.taobao.org/loader-utils/download/loader-utils-0.2.17.tgz",
-                    "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                },
+                "levn": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                    "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1",
-                        "object-assign": "4.1.1"
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2"
+                    }
+                },
+                "lodash.camelcase": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
+                    "integrity": "sha1-kyyLh/ikN3iXxnGXUzKC+Xrqwpg=",
+                    "requires": {
+                        "lodash._createcompounder": "3.0.0"
                     }
                 },
                 "lru-cache": {
-                    "version": "4.1.1",
-                    "resolved": "http://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.1.tgz",
-                    "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+                    "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
                     "requires": {
                         "pseudomap": "1.0.2",
                         "yallist": "2.1.2"
                     }
                 },
+                "optionator": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+                    "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+                    "requires": {
+                        "deep-is": "0.1.3",
+                        "fast-levenshtein": "2.0.6",
+                        "levn": "0.3.0",
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2",
+                        "wordwrap": "1.0.0"
+                    }
+                },
                 "path-exists": {
                     "version": "2.1.0",
-                    "resolved": "http://registry.npm.taobao.org/path-exists/download/path-exists-2.1.0.tgz",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "requires": {
                         "pinkie-promise": "2.0.1"
@@ -11835,42 +16329,130 @@
                 },
                 "pkg-dir": {
                     "version": "1.0.0",
-                    "resolved": "http://registry.npm.taobao.org/pkg-dir/download/pkg-dir-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
                     "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
                     "requires": {
                         "find-up": "1.1.2"
                     }
                 },
-                "vue-style-loader": {
-                    "version": "1.0.0",
-                    "resolved": "http://registry.npm.taobao.org/vue-style-loader/download/vue-style-loader-1.0.0.tgz",
-                    "integrity": "sha1-q+t70PRjEwg3QSRNMHnU8URJ4Ek=",
+                "postcss": {
+                    "version": "6.0.21",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+                    "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
                     "requires": {
-                        "loader-utils": "0.2.17"
+                        "chalk": "2.4.0",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.4.0"
+                    },
+                    "dependencies": {
+                        "ansi-styles": {
+                            "version": "3.2.1",
+                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                            "requires": {
+                                "color-convert": "1.9.1"
+                            }
+                        },
+                        "chalk": {
+                            "version": "2.4.0",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+                            "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+                            "requires": {
+                                "ansi-styles": "3.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "supports-color": "5.4.0"
+                            }
+                        },
+                        "has-flag": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+                        },
+                        "source-map": {
+                            "version": "0.6.1",
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                        },
+                        "supports-color": {
+                            "version": "5.4.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                            "requires": {
+                                "has-flag": "3.0.0"
+                            }
+                        }
+                    }
+                },
+                "source-list-map": {
+                    "version": "0.1.8",
+                    "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+                    "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY="
+                },
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
+                },
+                "vue-template-compiler": {
+                    "version": "2.5.16",
+                    "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.16.tgz",
+                    "integrity": "sha512-ZbuhCcF/hTYmldoUOVcu2fcbeSAZnfzwDskGduOrnjBiIWHgELAd+R8nAtX80aZkceWDKGQ6N9/0/EUpt+l22A==",
+                    "requires": {
+                        "de-indent": "1.0.2",
+                        "he": "1.1.1"
+                    }
+                },
+                "weex-styler": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/weex-styler/-/weex-styler-0.3.1.tgz",
+                    "integrity": "sha512-xkX5/wS/QLiJXKwbdpeytbLN0kHviQwj9CLdvBxqu+RRZABZpTniKZr1oxjh9Q0+n/aRC+smwFpQpUKvXh9V1g==",
+                    "requires": {
+                        "css": "2.2.1"
+                    }
+                },
+                "weex-template-compiler": {
+                    "version": "2.5.13-weex.3",
+                    "resolved": "https://registry.npmjs.org/weex-template-compiler/-/weex-template-compiler-2.5.13-weex.3.tgz",
+                    "integrity": "sha512-Zz8OV5x1CanfpUZqV9JR4WD/8X+f1rIjT0SnARm9apKcF/Fd8z3jRHjk/YnYrm6pQPtUnat1cASSZ4CuX25GiA==",
+                    "requires": {
+                        "acorn": "5.2.1",
+                        "escodegen": "1.9.1",
+                        "he": "1.1.1",
+                        "vue-template-es2015-compiler": "1.6.0"
                     }
                 },
                 "weex-vue-loader": {
-                    "version": "0.2.12",
-                    "resolved": "http://registry.npm.taobao.org/weex-vue-loader/download/weex-vue-loader-0.2.12.tgz",
-                    "integrity": "sha1-onscX80seff56c0+hungov29c4Q=",
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/weex-vue-loader/-/weex-vue-loader-0.6.1.tgz",
+                    "integrity": "sha512-Sth0LRUN94YkVHDH2Czhznexws1gonH3Z/0nr2/9ZmWxqeZ4jGhOp0xAjxSY6nVC7B8Y31wexzFGSCR/Xx+O/g==",
                     "requires": {
+                        "babel-loader": "6.4.1",
                         "consolidate": "0.14.5",
+                        "css-loader": "0.23.1",
                         "hash-sum": "1.0.2",
                         "he": "1.1.1",
                         "js-beautify": "1.7.4",
-                        "loader-utils": "0.2.17",
-                        "lru-cache": "4.1.1",
+                        "loader-utils": "1.1.0",
+                        "lru-cache": "4.1.2",
                         "object-assign": "4.1.1",
-                        "postcss": "5.2.18",
+                        "postcss": "6.0.21",
                         "postcss-selector-parser": "2.2.3",
                         "source-map": "0.5.7",
                         "vue-hot-reload-api": "2.2.3",
-                        "vue-style-loader": "1.0.0",
-                        "vue-template-compiler": "2.5.3",
+                        "vue-style-loader": "3.0.3",
+                        "vue-template-compiler": "2.5.16",
                         "vue-template-es2015-compiler": "1.6.0",
-                        "weex-styler": "0.1.10",
-                        "weex-template-compiler": "2.1.10-weex.2"
+                        "weex-styler": "0.3.1",
+                        "weex-template-compiler": "2.5.13-weex.3"
                     }
+                },
+                "wordwrap": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
                 }
             }
         },
@@ -11904,14 +16486,6 @@
             "integrity": "sha1-irikZIsmHwFX09LZlCu1xfbxiRw=",
             "requires": {
                 "css": "2.2.1"
-            }
-        },
-        "weex-template-compiler": {
-            "version": "2.1.10-weex.2",
-            "resolved": "http://registry.npm.taobao.org/weex-template-compiler/download/weex-template-compiler-2.1.10-weex.2.tgz",
-            "integrity": "sha1-fyQHRfCYSRbDjHpSmmPXDy5yqHA=",
-            "requires": {
-                "he": "1.1.1"
             }
         },
         "weex-templater": {
@@ -11999,92 +16573,6 @@
                     "integrity": "sha1-wYYrDly1+C+cmzFfF3nru6S3SXE=",
                     "requires": {
                         "css": "2.2.1"
-                    }
-                }
-            }
-        },
-        "weex-vue-loader": {
-            "version": "0.4.2",
-            "resolved": "http://registry.npm.taobao.org/weex-vue-loader/download/weex-vue-loader-0.4.2.tgz",
-            "integrity": "sha1-fLvUqg8Rhiymg6Fsb28bHbsryjk=",
-            "requires": {
-                "consolidate": "0.14.5",
-                "hash-sum": "1.0.2",
-                "he": "1.1.1",
-                "js-beautify": "1.7.4",
-                "loader-utils": "0.2.17",
-                "lru-cache": "4.1.1",
-                "object-assign": "4.1.1",
-                "postcss": "6.0.14",
-                "postcss-selector-parser": "2.2.3",
-                "source-map": "0.5.7",
-                "vue-hot-reload-api": "2.2.3",
-                "vue-style-loader": "3.0.3",
-                "vue-template-compiler": "2.5.3",
-                "vue-template-es2015-compiler": "1.6.0",
-                "weex-styler": "0.2.7",
-                "weex-template-compiler": "2.4.2-weex.3"
-            },
-            "dependencies": {
-                "loader-utils": {
-                    "version": "0.2.17",
-                    "resolved": "http://registry.npm.taobao.org/loader-utils/download/loader-utils-0.2.17.tgz",
-                    "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                    "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1",
-                        "object-assign": "4.1.1"
-                    }
-                },
-                "lru-cache": {
-                    "version": "4.1.1",
-                    "resolved": "http://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.1.tgz",
-                    "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
-                    "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
-                    }
-                },
-                "postcss": {
-                    "version": "6.0.14",
-                    "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-6.0.14.tgz",
-                    "integrity": "sha1-VTTHIRRznnXQr88BfbhTCZ9WKIU=",
-                    "requires": {
-                        "chalk": "2.3.0",
-                        "source-map": "0.6.1",
-                        "supports-color": "4.5.0"
-                    },
-                    "dependencies": {
-                        "source-map": {
-                            "version": "0.6.1",
-                            "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
-                            "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
-                        }
-                    }
-                },
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
-                },
-                "weex-styler": {
-                    "version": "0.2.7",
-                    "resolved": "http://registry.npm.taobao.org/weex-styler/download/weex-styler-0.2.7.tgz",
-                    "integrity": "sha1-wYYrDly1+C+cmzFfF3nru6S3SXE=",
-                    "requires": {
-                        "css": "2.2.1"
-                    }
-                },
-                "weex-template-compiler": {
-                    "version": "2.4.2-weex.3",
-                    "resolved": "http://registry.npm.taobao.org/weex-template-compiler/download/weex-template-compiler-2.4.2-weex.3.tgz",
-                    "integrity": "sha1-KTPcG8L8jh0PUVU5JM5CtTD+9+g=",
-                    "requires": {
-                        "he": "1.1.1"
                     }
                 }
             }
@@ -12183,6 +16671,14 @@
             "resolved": "http://registry.npm.taobao.org/wrappy/download/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
+        "write": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "requires": {
+                "mkdirp": "0.5.1"
+            }
+        },
         "write-file-atomic": {
             "version": "2.3.0",
             "resolved": "http://registry.npm.taobao.org/write-file-atomic/download/write-file-atomic-2.3.0.tgz",
@@ -12191,6 +16687,15 @@
                 "graceful-fs": "4.1.11",
                 "imurmurhash": "0.1.4",
                 "signal-exit": "3.0.2"
+            }
+        },
+        "ws": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+            "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+            "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1"
             }
         },
         "xdg-basedir": {

--- a/utils/vue-loader/lib/loader.js
+++ b/utils/vue-loader/lib/loader.js
@@ -55,7 +55,7 @@ module.exports = function (content) {
   var moduleId = 'data-v-' + genId(filePath)
   var styleRewriter = styleRewriterPath + '?id=' + moduleId
 
-  var isProduction = this.minimize || process.env.NODE_ENV === 'production'
+  var isProduction = this.minimize || process.env.NODE_ENV !== 'development'
 
   var needCssSourceMap =
     !isProduction &&

--- a/utils/vue-loader/lib/style-rewriter.js
+++ b/utils/vue-loader/lib/style-rewriter.js
@@ -73,7 +73,7 @@ module.exports = function (css, map) {
     this.sourceMap &&
     !this.minimize &&
     options.cssSourceMap !== false &&
-    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV === 'development' &&
     !(isObject(postcssOptions) && postcssOptions.options && postcssOptions.map)
   ) {
     opts.map = {

--- a/utils/vue-loader/lib/template-compiler.js
+++ b/utils/vue-loader/lib/template-compiler.js
@@ -85,7 +85,7 @@ module.exports = function (html) {
   // hot-reload
   if (!isServer &&
       !this.minimize &&
-      process.env.NODE_ENV !== 'production') {
+      process.env.NODE_ENV === 'development') {
     code +=
       '\nif (module.hot) {\n' +
       '  module.hot.accept()\n' +


### PR DESCRIPTION
现在脚手架是将NODE_ENV 在pack的时候会写死一个“production” ，但是在很多情况下，应用会有分环境需求，而通常会用process.env.NODE_ENV 来分当前环境，写死的话不太方便。
希望可以采纳！